### PR TITLE
State root mismatch fix

### DIFF
--- a/src/gnosis.rs
+++ b/src/gnosis.rs
@@ -193,8 +193,8 @@ where
         }
     } else {
         should_create = true;
-    }    
-    
+    }
+
     // Clean-up post system tx context
     if should_create {
         // Populate system account on first block
@@ -208,7 +208,7 @@ where
         // Conditionally clear the system address account to prevent being removed
         state.remove(&SYSTEM_ADDRESS);
     }
-    
+
     state.remove(&evm.block().coinbase);
     evm.context.evm.db.commit(state);
     // re-set the previous env

--- a/src/gnosis.rs
+++ b/src/gnosis.rs
@@ -195,6 +195,7 @@ where
         should_create = true;
     }
 
+    // system account call is only in rewards function because it will be called in every block
     // Clean-up post system tx context
     if should_create {
         // Populate system account on first block

--- a/src/gnosis.rs
+++ b/src/gnosis.rs
@@ -15,6 +15,7 @@ use reth::{
 use reth_chainspec::ChainSpec;
 use reth_errors::BlockValidationError;
 use reth_evm::{execute::BlockExecutionError, ConfigureEvm};
+use revm_primitives::{Account, AccountInfo, AccountStatus};
 
 pub const SYSTEM_ADDRESS: Address = address!("fffffffffffffffffffffffffffffffffffffffe");
 
@@ -184,8 +185,30 @@ where
         })
     })?;
 
+    // figure out if we should create the system account
+    let mut should_create = false;
+    if let Some(system_account) = state.get(&SYSTEM_ADDRESS) {
+        if system_account.status == (AccountStatus::Touched | AccountStatus::LoadedAsNotExisting) {
+            should_create = true;
+        }
+    } else {
+        should_create = true;
+    }    
+    
     // Clean-up post system tx context
-    state.remove(&SYSTEM_ADDRESS);
+    if should_create {
+        // Populate system account on first block
+        let account = Account {
+            info: AccountInfo::default(),
+            storage: Default::default(),
+            status: AccountStatus::Touched | AccountStatus::Created,
+        };
+        state.insert(SYSTEM_ADDRESS, account);
+    } else {
+        // Conditionally clear the system address account to prevent being removed
+        state.remove(&SYSTEM_ADDRESS);
+    }
+    
     state.remove(&evm.block().coinbase);
     evm.context.evm.db.commit(state);
     // re-set the previous env


### PR DESCRIPTION
* adds conditional logic for system address to maintain consistency with nethermind in both genesis hash and state root
    * adds system address as new account if it's loaded without existing (converted to touched + created)
    * removes system address from state transitions from block 2 onwards to prevent it being wiped in accordance to EIP-158/161