### PR TITLE
CLI with Gnosis arguments (block import and state init)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 mod consensus;
 mod errors;
 mod evm_config;
-mod execute;
+pub mod execute;
 mod gnosis;
 mod payload_builder;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,14 @@
 use clap::{Args, Parser};
-use reth::{chainspec::EthereumChainSpecParser, cli::Cli};
-use reth_gnosis::GnosisNode;
+use reth::{
+    chainspec::EthereumChainSpecParser,
+    cli::{Cli, Commands},
+    CliRunner,
+};
+use reth_gnosis::{
+    execute::{GnosisExecutionStrategyFactory, GnosisExecutorProvider},
+    GnosisNode,
+};
+use reth_node_ethereum::BasicBlockExecutorProvider;
 
 // We use jemalloc for performance reasons
 #[cfg(all(feature = "jemalloc", unix))]
@@ -20,12 +28,40 @@ fn main() {
         std::env::set_var("RUST_BACKTRACE", "1");
     }
 
-    if let Err(err) = Cli::<EthereumChainSpecParser, NoArgs>::parse().run(|builder, _| async move {
-        let handle = builder.node(GnosisNode::new()).launch().await?;
+    let cli = Cli::<EthereumChainSpecParser, NoArgs>::parse();
+    let _ = cli.init_tracing().unwrap();
 
-        handle.node_exit_future.await
-    }) {
-        eprintln!("Error: {err:?}");
-        std::process::exit(1);
+    match cli.command {
+        Commands::Import(command) => {
+            dbg!("Importing with custom cli");
+            let runner = CliRunner::default();
+            let res = runner.run_blocking_until_ctrl_c(command.execute::<GnosisNode, _, _>(
+                |chain_spec| -> BasicBlockExecutorProvider<GnosisExecutionStrategyFactory> {
+                    GnosisExecutorProvider::gnosis(chain_spec)
+                },
+            ));
+            if let Err(err) = res {
+                eprintln!("Error: {err:?}");
+                std::process::exit(1);
+            }
+        }
+        Commands::InitState(command) => {
+            let runner = CliRunner::default();
+            let res = runner.run_blocking_until_ctrl_c(command.execute::<GnosisNode>());
+            if let Err(err) = res {
+                eprintln!("Error: {err:?}");
+                std::process::exit(1);
+            }
+        }
+        _ => {
+            if let Err(err) = cli.run(|builder, _| async move {
+                let handle = builder.node(GnosisNode::new()).launch().await?;
+
+                handle.node_exit_future.await
+            }) {
+                eprintln!("Error: {err:?}");
+                std::process::exit(1);
+            }
+        }
     }
 }


### PR DESCRIPTION
Custom CLI wrapper to use Gnosis Node and Gnosis Executor instead of Ethereum defaults. This implements custom cli for block imports (in concatenated RLP; only post-merge) and state initialization from state dump. This enables state import without evm.

How to test it out the `init-state` command:

* First download the state export from Geth (Gnosis Mainnet) at the block height 57936 here: [block_57936.jsonl](https://raw.githubusercontent.com/debjit-bw/reth/refs/heads/without-evm-examples/block_57936.jsonl)
* Download the custom header from here: [header.rlp](https://raw.githubusercontent.com/debjit-bw/reth/refs/heads/without-evm-examples/new_header.rlp) (this is a mock header with the block hash at mainnet block 57936)
* [IMPORTANT] Empty the state in the genesis alloc (`alloc: {}`). This is because we aren't loading the chain from genesis, and instead the state will be the exact one in the JSONL file. If you don't do this, you might get state root mismatches.

Then run:

```sh
./target/debug/reth --chain ./scripts/chiado_genesis_alloc.json init-state ./block_57936.jsonl --without-evm --header ./new_header.rlp --total-difficulty 0 --header-hash 940b2930e73c2088120f1246b9263e99fda2584b15c7eca32196fa6e023df7d2
```