### PR TITLE
Logic change for withdrawals

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -232,7 +232,7 @@ where
     fn apply_post_execution_changes(
         &mut self,
         block: &BlockWithSenders,
-        total_difficulty: U256,
+        _total_difficulty: U256,
         receipts: &[Receipt],
     ) -> Result<Requests, Self::Error> {
         let cfg = CfgEnvWithHandlerCfg::new(Default::default(), Default::default());
@@ -250,9 +250,6 @@ where
             block.beneficiary,
         )?;
 
-        let env = self.evm_env_for_block(&block.header, total_difficulty);
-        let mut evm = self.evm_config.evm_with_env(&mut self.state, env);
-
         let requests = if self
             .chain_spec
             .is_prague_active_at_timestamp(block.timestamp)
@@ -260,9 +257,7 @@ where
             // Collect all EIP-6110 deposits
             let deposit_requests = parse_deposits_from_receipts(&self.chain_spec, receipts)?;
 
-            let mut requests = Requests::new(vec![deposit_requests]);
-            requests.extend(self.system_caller.apply_post_execution_changes(&mut evm)?);
-            requests
+            Requests::new(vec![deposit_requests])
         } else {
             Requests::default()
         };

--- a/src/payload_builder.rs
+++ b/src/payload_builder.rs
@@ -18,9 +18,8 @@ use reth::{
     transaction_pool::{noop::NoopTransactionPool, BestTransactionsAttributes, TransactionPool},
 };
 use reth_basic_payload_builder::{
-    commit_withdrawals, is_better_payload, BasicPayloadJobGenerator,
-    BasicPayloadJobGeneratorConfig, BuildArguments, BuildOutcome, PayloadBuilder, PayloadConfig,
-    WithdrawalsOutcome,
+    is_better_payload, BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig, BuildArguments,
+    BuildOutcome, PayloadBuilder, PayloadConfig, WithdrawalsOutcome,
 };
 use reth_chain_state::ExecutedBlock;
 use reth_chainspec::{ChainSpec, EthereumHardforks};
@@ -423,34 +422,6 @@ where
         });
     }
 
-    // calculate the requests and the requests root
-    let requests = if chain_spec.is_prague_active_at_timestamp(attributes.timestamp) {
-        let deposit_requests = parse_deposits_from_receipts(&chain_spec, receipts.iter().flatten())
-            .map_err(|err| PayloadBuilderError::Internal(RethError::Execution(err.into())))?;
-        let withdrawal_requests = system_caller
-            .post_block_withdrawal_requests_contract_call(
-                &mut db,
-                &initialized_cfg,
-                &initialized_block_env,
-            )
-            .map_err(|err| PayloadBuilderError::Internal(err.into()))?;
-        let consolidation_requests = system_caller
-            .post_block_consolidation_requests_contract_call(
-                &mut db,
-                &initialized_cfg,
-                &initialized_block_env,
-            )
-            .map_err(|err| PayloadBuilderError::Internal(err.into()))?;
-
-        Some(Requests::new(vec![
-            deposit_requests,
-            withdrawal_requests,
-            consolidation_requests,
-        ]))
-    } else {
-        None
-    };
-
     // < GNOSIS SPECIFIC
     apply_post_block_system_calls(
         &chain_spec,
@@ -466,15 +437,31 @@ where
     .map_err(|err| PayloadBuilderError::Internal(err.into()))?;
     // GNOSIS SPECIFIC >
 
+    // calculate the requests and the requests root
+    let requests = if chain_spec.is_prague_active_at_timestamp(attributes.timestamp) {
+        let deposit_requests = parse_deposits_from_receipts(&chain_spec, receipts.iter().flatten())
+            .map_err(|err| PayloadBuilderError::Internal(RethError::Execution(err.into())))?;
+        Some(Requests::new(vec![deposit_requests]))
+    } else {
+        None
+    };
+
     let WithdrawalsOutcome {
         withdrawals_root,
         withdrawals,
-    } = commit_withdrawals(
-        &mut db,
-        &chain_spec,
-        attributes.timestamp,
-        attributes.withdrawals,
-    )?;
+    } = if !chain_spec.is_shanghai_active_at_timestamp(attributes.timestamp) {
+        WithdrawalsOutcome::pre_shanghai()
+    } else if attributes.withdrawals.is_empty() {
+        WithdrawalsOutcome::empty()
+    } else {
+        let withdrawals_root = proofs::calculate_withdrawals_root(&attributes.withdrawals);
+
+        // calculate withdrawals root
+        WithdrawalsOutcome {
+            withdrawals: Some(attributes.withdrawals),
+            withdrawals_root: Some(withdrawals_root),
+        }
+    };
 
     // merge all transitions into bundle state, this would apply the withdrawal balance changes
     // and 4788 contract call


### PR DESCRIPTION
This PR fixes the block building and block execution differences w.r.t. withdrawals:
* system caller's post block logic removed (they call hardcoded eth mainnet deposit contract, while we have our own logic)
* withdrawal and block consolidation calls removed (because we dont have eip 7251 yet)
* withdrawals commitment involves just making the root, and not balance increments like commit_withdrawals does