### PR TITLE
fix - state persistence for post execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7679,6 +7679,7 @@ dependencies = [
  "reth-primitives",
  "reth-provider",
  "reth-prune-types",
+ "reth-revm",
  "reth-rpc",
  "reth-stages",
  "reth-stages-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 [dependencies]
 reth = { git = "https://github.com/paradigmxyz/reth", rev = "8f61af0136e1a20119832925081c341ae89b93f0" }
 reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8f61af0136e1a20119832925081c341ae89b93f0" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8f61af0136e1a20119832925081c341ae89b93f0" }
 reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8f61af0136e1a20119832925081c341ae89b93f0" }
 reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8f61af0136e1a20119832925081c341ae89b93f0" }
 reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8f61af0136e1a20119832925081c341ae89b93f0" }


### PR DESCRIPTION
Using an `evm` constructed inside post execution in `gnosis.rs` was not persisting the changes (for example even when new accounts were forcefully being created). This resulted in mismatched state roots (because the rewards contract call changes the storage roots). Now we are passing the `evm` mutably from post_execution function instead of constructing inside.

Some traits have been changed, so the evm passed inside post_execution no longer has `increment_balances` in `evm.context.evm.db`. Therefore, refactored to bring the `balance_increments` outside in post_execution function to match with [paradigmxyz/reth](https://github.com/debjit-bw/reth/blob/dd055a4615c2e8fc42f63103bb3c3d369349a85d/crates/ethereum/evm/src/execute.rs#L266-L267).

### Final Result
✅ Can sync mainnet blocks post-merge. Currently syncing Merge fork (1000 blocks applied). Not reached Shanghai.