### PR TITLE
feat - CI pushes client images to repository

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,7 +128,7 @@ jobs:
  
   build-and-push-image:
     runs-on: ubuntu-latest
-    needs: tests
+    # needs: tests
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 env:
   REQWEST_TEST_BODY_FULL: 1
   RUST_BACKTRACE: 1
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   style:
@@ -34,29 +36,29 @@ jobs:
       - run: cargo check --all-targets
       - run: cargo clippy -- --deny warnings
 
-  spec-tests:
-    name: Spec tests
-    runs-on: 'ubuntu-latest'
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust || 'stable' }}
-          targets: ${{ matrix.target }}
-      - name: Downloading ethereum/tests
-        run: git clone https://github.com/ethereum/tests ethereum-tests
-      - name: Downloading EELS fixtures released at Cancun
-        run: curl -LO https://github.com/ethereum/execution-spec-tests/releases/download/v2.1.1/fixtures.tar.gz && tar -xzf fixtures.tar.gz
-      - name: Test specs (EELS and ethereum/tests)
-        run: cargo test --features testing
+  # spec-tests:
+  #   name: Spec tests
+  #   runs-on: 'ubuntu-latest'
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           ~/.cargo/registry
+  #           ~/.cargo/git
+  #           target
+  #         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+  #     - name: Install rust
+  #       uses: dtolnay/rust-toolchain@master
+  #       with:
+  #         toolchain: ${{ matrix.rust || 'stable' }}
+  #         targets: ${{ matrix.target }}
+  #     - name: Downloading ethereum/tests
+  #       run: git clone https://github.com/ethereum/tests ethereum-tests
+  #     - name: Downloading EELS fixtures released at Cancun
+  #       run: curl -LO https://github.com/ethereum/execution-spec-tests/releases/download/v2.1.1/fixtures.tar.gz && tar -xzf fixtures.tar.gz
+  #     - name: Test specs (EELS and ethereum/tests)
+  #       run: cargo test --features testing
 
   tests:
     name: Tests ${{ matrix.name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,10 @@
 name: Test
 
 on:
-  pull_request:
   push:
     branches:
       - master
+      - ci-test
 
 env:
   REQWEST_TEST_BODY_FULL: 1
@@ -126,19 +126,37 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
  
-  docker-build:
+  build-and-push-image:
     runs-on: ubuntu-latest
+    needs: test
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      # 
     steps:
-      - uses: actions/checkout@v3
-      - uses: docker/setup-buildx-action@v2
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56
         with:
           context: .
-          load: true
-          tags: blobshare:dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      - name: Test image
-        run: docker run --rm blobshare:dev --help
-
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,11 @@
 name: Test
 
+# TODO: DO NOT BUILD AND PUSH ON PR's BUT RUN EVERYTHING ELSE
 on:
+  pull_request:
   push:
     branches:
       - master
-      - ci-test
 
 env:
   REQWEST_TEST_BODY_FULL: 1
@@ -36,29 +37,29 @@ jobs:
       - run: cargo check --all-targets
       - run: cargo clippy -- --deny warnings
 
-  # spec-tests:
-  #   name: Spec tests
-  #   runs-on: 'ubuntu-latest'
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           ~/.cargo/registry
-  #           ~/.cargo/git
-  #           target
-  #         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-  #     - name: Install rust
-  #       uses: dtolnay/rust-toolchain@master
-  #       with:
-  #         toolchain: ${{ matrix.rust || 'stable' }}
-  #         targets: ${{ matrix.target }}
-  #     - name: Downloading ethereum/tests
-  #       run: git clone https://github.com/ethereum/tests ethereum-tests
-  #     - name: Downloading EELS fixtures released at Cancun
-  #       run: curl -LO https://github.com/ethereum/execution-spec-tests/releases/download/v2.1.1/fixtures.tar.gz && tar -xzf fixtures.tar.gz
-  #     - name: Test specs (EELS and ethereum/tests)
-  #       run: cargo test --features testing
+  spec-tests:
+    name: Spec tests
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust || 'stable' }}
+          targets: ${{ matrix.target }}
+      - name: Downloading ethereum/tests
+        run: git clone https://github.com/ethereum/tests ethereum-tests
+      - name: Downloading EELS fixtures released at Cancun
+        run: curl -LO https://github.com/ethereum/execution-spec-tests/releases/download/v2.1.1/fixtures.tar.gz && tar -xzf fixtures.tar.gz
+      - name: Test specs (EELS and ethereum/tests)
+        run: cargo test --features testing
 
   tests:
     name: Tests ${{ matrix.name }}
@@ -129,6 +130,7 @@ jobs:
           RUSTDOCFLAGS: -D warnings
  
   build-and-push-image:
+    if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     # needs: tests
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,7 +128,7 @@ jobs:
  
   build-and-push-image:
     runs-on: ubuntu-latest
-    needs: test
+    needs: tests
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read


### PR DESCRIPTION
CI improvement to build and push the client images to github container registry. This is in response to integrating hive tests.