### PR TITLE
fix - Update Nethermind field eip1559FeeCollector name

### DIFF
--- a/scripts/networkdata/chainspec.json
+++ b/scripts/networkdata/chainspec.json
@@ -56,7 +56,7 @@
     "maxCodeSize": "0x6000",
     "eip1559BaseFeeMaxChangeDenominator": "0x8",
     "eip1559ElasticityMultiplier": "0x2",
-    "eip1559FeeCollector": "0x1559000000000000000000000000000000000000",
+    "feeCollector": "0x1559000000000000000000000000000000000000",
     "eip1559FeeCollectorTransition": 0,
     "registrar": "0x6000000000000000000000000000000000000000",
     "transactionPermissionContract": "0x4000000000000000000000000000000000000001",


### PR DESCRIPTION
In their latest release, Nethermind changed the name of the field from `eip1559FeeCollector` to `feeCollector`