### PR TITLE
fix - add multiple deposits from native bridge contract instead of replacing

### DIFF
--- a/src/gnosis.rs
+++ b/src/gnosis.rs
@@ -231,7 +231,10 @@ where
         .zip(result.rewardsNative.iter())
     {
         // TODO: .to panics if the return value is too large
-        balance_increments.insert(*address, amount.to::<u128>());
+        balance_increments
+            .entry(*address)
+            .and_modify(|e| *e += amount.to::<u128>())
+            .or_insert_with(|| amount.to::<u128>());
     }
 
     Ok(balance_increments)

--- a/src/gnosis.rs
+++ b/src/gnosis.rs
@@ -231,10 +231,7 @@ where
         .zip(result.rewardsNative.iter())
     {
         // TODO: .to panics if the return value is too large
-        balance_increments
-            .entry(*address)
-            .and_modify(|e| *e += amount.to::<u128>())
-            .or_insert_with(|| amount.to::<u128>());
+        *balance_increments.entry(*address).or_default() += amount.to::<u128>();
     }
 
     Ok(balance_increments)


### PR DESCRIPTION
If an address received multiple deposits (say, 100, 200 and 300) In the earlier implementation, the final credit was 300 because each value replaced the earlier. The current implementation changes that so the address receives 600 (=100+200+300).