### PR TITLE
fix - Activate EIP-170 at Shanghai

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -1,4 +1,5 @@
 extern crate alloc;
+use crate::evm_config::get_cfg_env;
 use crate::evm_config::GnosisEvmConfig;
 
 use crate::gnosis::apply_post_block_system_calls;
@@ -26,7 +27,6 @@ use reth_node_ethereum::BasicBlockExecutorProvider;
 use reth_primitives::EthPrimitives;
 use reth_primitives::{BlockWithSenders, Receipt};
 use reth_revm::db::State;
-use revm_primitives::CfgEnv;
 use revm_primitives::{
     db::{Database, DatabaseCommit},
     BlockEnv, CfgEnvWithHandlerCfg, EnvWithHandlerCfg, ResultAndState, U256,
@@ -141,13 +141,7 @@ where
     ///
     /// Caution: this does not initialize the tx environment.
     fn evm_env_for_block(&self, header: &Header, total_difficulty: U256) -> EnvWithHandlerCfg {
-        let mut cfg_env = CfgEnv::default().with_chain_id(self.chain_spec.chain().id());
-        if !self
-            .chain_spec
-            .is_shanghai_active_at_timestamp(header.timestamp)
-        {
-            cfg_env.limit_contract_code_size = Some(usize::MAX);
-        }
+        let cfg_env = get_cfg_env(&self.chain_spec, header.timestamp);
 
         let mut cfg = CfgEnvWithHandlerCfg::new(cfg_env, Default::default());
         let mut block_env = BlockEnv::default();


### PR DESCRIPTION
Activates EIP-170 at a different fork in Gnosis Chain (Shanghai) compared to Ethereum Mainnet (Spurious Dragon). Unless Shanghai is active, contracts of any size are allowed.

This problem was detected while applying block [#26688928](https://gnosisscan.io/block/26688928).