### PR TITLE
Bump reth to 2933ec7

### DIFF
--- a/.github/workflows/post-merge-run.yml
+++ b/.github/workflows/post-merge-run.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       SQLX_OFFLINE: true
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -42,7 +42,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -114,7 +114,7 @@ jobs:
       SQLX_OFFLINE: true
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab9d1367c6ffb90c93fb4a9a4989530aa85112438c6f73a734067255d348469"
+checksum = "5d0d6c784abf2e061139798d51299da278fc8f02d7b7546662b898d9b22ab5e9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4138dc275554afa6f18c4217262ac9388790b2fc393c2dfe03c51d357abf013"
+checksum = "ce20c85f6b24a5da40b2350a748e348417f0465dedbb523a4d149143bc4a41ce"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa04e1882c31288ce1028fdf31b6ea94cfa9eafa2e497f903ded631c8c6a42c"
+checksum = "8e23af02ccded0031ef2b70df4fe9965b1c742c5d5384c8c767ae0311f7e62b9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9138f4f0912793642d453523c3116bd5d9e11de73b70177aa7cb3e94b98ad2"
+checksum = "7f2d547eba3f2d331b0e08f64a24e202f66d4f291e2a3e0073914c0e1400ced3"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -208,16 +208,18 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dd5869ed09e399003e0e0ec6903d981b2a92e74c5d37e6b40890bad2517526"
+checksum = "7149e011edbd588f6df6564b369c75f6b538d76db14053d95e0b43b2d92e4266"
 dependencies = [
+ "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "arbitrary",
+ "auto_impl",
  "c-kzg",
  "derive_more",
  "ethereum_ssz",
@@ -229,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d2a7fe5c1a9bd6793829ea21a636f30fc2b3f5d2e7418ba86d96e41dd1f460"
+checksum = "acaec0cc4c1489d61d6f33d0c3dd522c750025f4b5c8f59cd546221e4df660e5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -242,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24acd2f5ba97c7a320e67217274bc81fe3c3174b8e6144ec875d9d54e760e278"
+checksum = "d62cf1b25f5a50ca2d329b0b4aeb0a0dedeaf225ad3c5099d83b1a4c4616186e"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -254,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2008bedb8159a255b46b7c8614516eda06679ea82f620913679afbd8031fea72"
+checksum = "c0c5c9651fd20a2fd4a57606b6a570d1c17ab86e686b962b2f1ecac68b51e020"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -268,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4556f01fe41d0677495df10a648ddcf7ce118b0e8aa9642a0e2b6dd1fb7259de"
+checksum = "b02ed56783fb2c086a4ac8961175dd6d3ad163e6cf6125f0b83f7de03379b607"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -293,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31c3c6b71340a1d076831823f09cb6e02de01de5c6630a9631bdb36f947ff80"
+checksum = "a0624cfa9311aa8283cd3bf5eed883d0d1e823e2a4d57b30e1b49af4b3678a6b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -306,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec878088ec6283ce1e90d280316aadd3d6ce3de06ff63d68953c855e7e447e92"
+checksum = "bc1360603efdfba91151e623f13a4f4d3dc4af4adc1cbd90bf37c81e84db4c77"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -329,7 +331,7 @@ dependencies = [
  "proptest-derive",
  "rand",
  "ruint",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "sha3",
  "tiny-keccak",
@@ -337,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22c4441b3ebe2d77fa9cf629ba68c3f713eb91779cff84275393db97eddd82"
+checksum = "07c68df5354225da542efeb6d9388b65773b3304309b437416146e9d1e2bc1bd"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -353,18 +355,18 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-transport-ipc",
  "alloy-transport-ws",
  "async-stream",
  "async-trait",
  "auto_impl",
- "dashmap",
+ "dashmap 6.1.0",
  "futures",
  "futures-utils-wasm",
- "lru",
+ "lru 0.13.0",
  "parking_lot",
  "pin-project",
  "reqwest",
- "schnellru",
  "serde",
  "serde_json",
  "thiserror 2.0.11",
@@ -376,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2269fd635f7b505f27c63a3cb293148cd02301efce4c8bdd9ff54fbfc4a20e23"
+checksum = "7ef6ef167ea24e7aac569dfd90b668c1f7dca0e48214e70364586d5341a89431"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -412,20 +414,21 @@ checksum = "a40e1ef334153322fd878d07e86af7a529bcb86b2439525920a88eba87bcf943"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06a292b37e182e514903ede6e623b9de96420e8109ce300da288a96d88b7e4b"
+checksum = "0371aae9b44a35e374c94c7e1df5cbccf0f52b2ef7c782291ed56e86d88ec106"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-transport-ipc",
  "alloy-transport-ws",
  "futures",
  "pin-project",
@@ -442,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9383845dd924939e7ab0298bbfe231505e20928907d7905aa3bf112287305e06"
+checksum = "1428d64569961b00373c503a3de306656e94ef1f2a474e93fd41a6daae0d6ac7"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -455,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fcea70b3872c645fa0ee7fb23370d685f98e8c35f47297de619fb2e9f607ff"
+checksum = "b1d25e16c2be6518be9274ab16fe19190666d4330d0713aa14938f593ddb0098"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -467,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11495cb8c8d3141fc27556a4c9188b81531ad5ec3076a0394c61a6dcfbce9f34"
+checksum = "d721727cc493a58bd197a3ebbd42b88c0393c1f30da905bb7a31686c820f4c2d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -479,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca445cef0eb6c2cf51cfb4e214fbf1ebd00893ae2e6f3b944c8101b07990f988"
+checksum = "66e119337400d8b0348e1576ab37ffa56d1a04cbc977a84d4fa0a527d7cb0c21"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -490,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4009405b1d3f5e8c529b8cf353f74e815fd2102549af4172fc721b4b9ea09133"
+checksum = "9deadb4c8927dc702b58c8fb675f9fb88782c4c9c95096682058c1574141b8b7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -506,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "358d6a8d7340b9eb1a7589a6c1fb00df2c9b26e90737fa5ed0108724dd8dac2c"
+checksum = "fea98e1c4ac005ffe5f8691164f5f2ef5ee8dda50b1fdba173d44892141909e2"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -516,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f821f30344862a0b6eb9a1c2eb91dfb2ff44c7489f37152a526cdcab79264"
+checksum = "b582c59b6f493d9b15bea32f44f662fa6749e5464ef5305d8429a864ace60684"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -537,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0938bc615c02421bd86c1733ca7205cc3d99a122d9f9bff05726bd604b76a5c2"
+checksum = "8a4a43d8b1344e3ef115ed7a2cee934876e4a64d2b9d9bee8738f9806900757e"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -550,7 +553,7 @@ dependencies = [
  "alloy-serde",
  "alloy-sol-types",
  "arbitrary",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "jsonrpsee-types",
  "serde",
  "serde_json",
@@ -559,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06bd42cf54b8a05b596322267f396a7dbdf141a56e93502a2ab4464fb718467a"
+checksum = "076b5ed023c0b0e025566cfc570b51a6fd975935c982617c130ca98dcb0c1390"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -573,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd38207e056cc7d1372367fbb4560ddf9107cbd20731743f641246bf0dede149"
+checksum = "ac383c60b09660b7695a4f210cd11ab05887d058dfc669efd814904dbbaead82"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -587,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7fd456a3fa9ea732d1c0611c9d52b5326ee29f4d02d01b07dac453ed68d9eb5"
+checksum = "ac39b1a583bb59dcf7d856604867acf704a7cf70b76a42f895652d566aa6f17c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -599,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0465c71d4dced7525f408d84873aeebb71faf807d22d74c4a426430ccd9b55"
+checksum = "86aa42c36e3c0db5bd9a7314e98aa261a61d5e3d6a0bd7e51fb8b0a3d6438481"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -611,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bfa395ad5cc952c82358d31e4c68b27bf4a89a5456d9b27e226e77dac50e4ff"
+checksum = "c613222abd016e03ba548f41db938a2c99108b59c0c66ca105eab1b7a2e6b40a"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -625,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdc63ce9eda1283fcbaca66ba4a414b841c0e3edbeef9c86a71242fc9e84ccc"
+checksum = "39163b956c81e8fd9605194d6b5b92dd93b0e0252810e69f9a4cebe3a8614f46"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -641,23 +644,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d039d267aa5cbb7732fa6ce1fd9b5e9e29368f580f80ba9d7a8450c794de4b2"
+checksum = "13f28f2131dc3a7b8e2cda882758ad4d5231ca26281b9861d4b18c700713e2da"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620ae5eee30ee7216a38027dec34e0585c55099f827f92f50d11e3d2d3a4a954"
+checksum = "1ee2da033256a3b27131c030933eab0460a709fbcc4d4bd57bf9a5650b2441c5"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -666,31 +669,31 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "syn-solidity",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9f7d057e00f8c5994e4ff4492b76532c51ead39353aa2ed63f8c50c0f4d52e"
+checksum = "4e9d9918b0abb632818bf27e2dfb86b209be8433baacf22100b190bbc0904bd4"
 dependencies = [
  "const-hex",
  "dunce",
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e60b084fe1aef8acecda2743ff2d93c18ff3eb67a2d3b12f62582a1e66ef5e"
+checksum = "a971129d242338d92009470a2f750d3b2630bc5da00a40a94d51f5d456b5712f"
 dependencies = [
  "serde",
  "winnow",
@@ -698,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1382302752cd751efd275f4d6ef65877ddf61e0e6f5ac84ef4302b79a33a31a"
+checksum = "75f306fc801b3aa2e3c4785b7b5252ec8b19f77b30e3b75babfd23849c81bd8c"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -711,13 +714,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17722a198f33bbd25337660787aea8b8f57814febb7c746bc30407bdfc39448"
+checksum = "40e2f34fcd849676c8fe274a6e72f0664dfede7ce06d12daa728d2e72f1b4393"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
- "futures-util",
  "futures-utils-wasm",
  "serde",
  "serde_json",
@@ -731,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1509599021330a31c4a6816b655e34bf67acb1cc03c564e09fd8754ff6c5de"
+checksum = "6e291c97c3c0ebb5d03c34e3a55c0f7c5bfa307536a2efaaa6fae4b3a4d09851"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -745,10 +747,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-transport-ws"
-version = "0.9.2"
+name = "alloy-transport-ipc"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58011745b2f17b334db40df9077d75b181f78360a5bc5c35519e15d4bfce15e2"
+checksum = "8d3e991f40d2d81c6ee036a34d81127bfec5fadf7e649791b5225181126c1959"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-pubsub",
+ "alloy-transport",
+ "bytes",
+ "futures",
+ "interprocess",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-transport-ws"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc8c544f7dc764735664756805f8b8b770020cc295a0b96b09cbefd099c172c7"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -864,7 +886,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1045,7 +1067,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1067,18 +1089,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.85"
+version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1100,9 +1122,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aurora-engine-modexp"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aef7712851e524f35fbbb74fa6599c5cd8692056a1c36f9ca0d2001b670e7e5"
+checksum = "518bc5745a6264b5fd7b09dffb9667e400ee9e2bbe18555fac75e1fe9afa0df9"
 dependencies = [
  "hex",
  "num",
@@ -1116,7 +1138,7 @@ checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1216,7 +1238,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1327,7 +1349,7 @@ dependencies = [
  "boa_string",
  "indexmap 2.7.1",
  "num-bigint",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -1347,7 +1369,7 @@ dependencies = [
  "boa_string",
  "bytemuck",
  "cfg-if",
- "dashmap",
+ "dashmap 6.1.0",
  "fast-float2",
  "hashbrown 0.15.2",
  "icu_normalizer",
@@ -1363,7 +1385,7 @@ dependencies = [
  "portable-atomic",
  "rand",
  "regress",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "ryu-js",
  "serde",
  "serde_json",
@@ -1400,7 +1422,7 @@ dependencies = [
  "indexmap 2.7.1",
  "once_cell",
  "phf",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "static_assertions",
 ]
 
@@ -1412,7 +1434,7 @@ checksum = "9fd3f870829131332587f607a7ff909f1af5fc523fd1b192db55fbbdf52e8d3c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "synstructure",
 ]
 
@@ -1432,7 +1454,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "regress",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -1449,7 +1471,7 @@ checksum = "7debc13fbf7997bf38bf8e9b20f1ad5e2a7d27a900e1f6039fe244ce30f589b5"
 dependencies = [
  "fast-float2",
  "paste",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "sptr",
  "static_assertions",
 ]
@@ -1517,6 +1539,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
+name = "bytecount"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+
+[[package]]
 name = "bytemuck"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,7 +1561,7 @@ checksum = "3fa76293b4f7bb636ab88fd78228235b5248b4d05cc589aed610f954af5d7c7a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1544,9 +1572,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 dependencies = [
  "serde",
 ]
@@ -1586,6 +1614,19 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.25",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "cargo_metadata"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
@@ -1615,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
 dependencies = [
  "jobserver",
  "libc",
@@ -1689,9 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1711,14 +1752,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1808,6 +1849,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -2029,7 +2090,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2053,7 +2114,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2064,7 +2125,20 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2104,7 +2178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2163,7 +2237,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2184,7 +2258,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "unicode-xid",
 ]
 
@@ -2277,7 +2351,7 @@ dependencies = [
  "hkdf",
  "lazy_static",
  "libp2p-identity",
- "lru",
+ "lru 0.12.5",
  "more-asserts",
  "multiaddr",
  "parking_lot",
@@ -2298,7 +2372,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2315,9 +2389,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
 
 [[package]]
 name = "ecdsa"
@@ -2420,7 +2494,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2431,7 +2505,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2451,6 +2525,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "ethereum_serde_utils"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,9 +2548,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862e41ea8eea7508f70cfd8cd560f0c34bb0af37c719a8e06c2672f0f031d8e5"
+checksum = "86da3096d1304f5f28476ce383005385459afeaf0eea08592b65ddbc9b258d16"
 dependencies = [
  "alloy-primitives",
  "ethereum_serde_utils",
@@ -2480,14 +2563,14 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz_derive"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d31ecf6640112f61dc34b4d8359c081102969af0edd18381fed2052f6db6a410"
+checksum = "d832a5c38eba0e7ad92592f7a22d693954637fbb332b4f669590d66a5c3183e5"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2675,7 +2758,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3321,7 +3404,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3378,7 +3461,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3475,7 +3558,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3550,6 +3633,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -3659,7 +3751,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -3704,7 +3796,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3772,11 +3864,11 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.0"
+version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "js-sys",
  "pem",
  "ring",
@@ -4021,6 +4113,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+dependencies = [
+ "hashbrown 0.15.2",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4093,14 +4194,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12779523996a67c13c84906a876ac6fe4d07a6e1adb54978378e13f199251a62"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.7.1",
@@ -4156,6 +4257,21 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "mini-moka"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c325dfab65f261f386debee8b0969da215b3fa0037e74c8a1234db7ba986d803"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap 5.5.3",
+ "skeptic",
+ "smallvec",
+ "tagptr",
+ "triomphe",
 ]
 
 [[package]]
@@ -4438,7 +4554,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4475,9 +4591,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -4485,9 +4601,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.9.6"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28dc4e397dd8969f7f98ea6454a5c531349a58c76e12448b0c2de6581df7b8c"
+checksum = "1363dd2454f473e2a2a6ee5eda585ecf94209319e35529bd703ddc5072798eb4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4503,9 +4619,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.9.6"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d05b5b5b3cff7f24eec2bc366f86a7ff0934678b1bda36d0ecaadba9504170"
+checksum = "b2e4fe1929b0e39130da37cb975c98d70418904ba7991a061799ad971dbd09fe"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -4552,30 +4668,32 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.12"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
+checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
 dependencies = [
  "arbitrary",
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
  "bytes",
+ "const_format",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
+ "rustversion",
  "serde",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.12"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
+checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4674,7 +4792,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4688,22 +4806,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
+checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
+checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4831,7 +4949,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4929,7 +5047,18 @@ checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
+dependencies = [
+ "bitflags 2.8.0",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
@@ -4972,7 +5101,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2",
  "thiserror 2.0.11",
@@ -4990,7 +5119,7 @@ dependencies = [
  "getrandom 0.2.15",
  "rand",
  "ring",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -5090,7 +5219,7 @@ dependencies = [
  "crossterm",
  "instability",
  "itertools 0.13.0",
- "lru",
+ "lru 0.12.5",
  "paste",
  "strum",
  "strum_macros",
@@ -5266,7 +5395,7 @@ dependencies = [
 [[package]]
 name = "reth"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5293,6 +5422,7 @@ dependencies = [
  "reth-errors",
  "reth-ethereum-cli",
  "reth-ethereum-payload-builder",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
  "reth-exex",
@@ -5336,7 +5466,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5355,7 +5485,6 @@ dependencies = [
  "reth-provider",
  "reth-revm",
  "reth-tasks",
- "reth-transaction-pool",
  "revm",
  "tokio",
  "tracing",
@@ -5364,7 +5493,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5393,7 +5522,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5412,7 +5541,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -5426,7 +5555,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "ahash",
  "alloy-consensus",
@@ -5470,6 +5599,7 @@ dependencies = [
  "reth-node-events",
  "reth-node-metrics",
  "reth-primitives",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-prune",
  "reth-stages",
@@ -5488,7 +5618,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -5498,7 +5628,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5516,7 +5646,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5535,18 +5665,18 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "reth-config"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -5560,7 +5690,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5573,7 +5703,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5586,7 +5716,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5610,7 +5740,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -5632,7 +5762,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-tracing",
  "reth-trie-common",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "strum",
  "sysinfo",
@@ -5643,7 +5773,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -5671,7 +5801,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -5700,7 +5830,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5716,7 +5846,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5742,7 +5872,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5766,7 +5896,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -5790,7 +5920,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5821,7 +5951,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -5852,7 +5982,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -5868,7 +5998,6 @@ dependencies = [
  "reth-evm",
  "reth-node-types",
  "reth-payload-builder",
- "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-provider",
  "reth-prune",
@@ -5882,12 +6011,13 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
+ "auto_impl",
  "futures",
  "reth-errors",
  "reth-execution-types",
@@ -5904,7 +6034,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "futures",
  "pin-project",
@@ -5927,7 +6057,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5937,7 +6067,7 @@ dependencies = [
  "derive_more",
  "futures",
  "metrics",
- "moka",
+ "mini-moka",
  "rayon",
  "reth-chain-state",
  "reth-consensus",
@@ -5949,7 +6079,6 @@ dependencies = [
  "reth-metrics",
  "reth-network-p2p",
  "reth-payload-builder",
- "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
  "reth-provider",
@@ -5971,7 +6100,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5981,6 +6110,7 @@ dependencies = [
  "futures",
  "itertools 0.13.0",
  "pin-project",
+ "reth-chainspec",
  "reth-consensus-common",
  "reth-engine-primitives",
  "reth-errors",
@@ -5993,7 +6123,6 @@ dependencies = [
  "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
- "reth-rpc-types-compat",
  "reth-trie",
  "revm-primitives",
  "serde",
@@ -6006,7 +6135,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -6018,7 +6147,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6046,7 +6175,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6067,7 +6196,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "eyre",
  "reth-chainspec",
@@ -6077,7 +6206,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6093,7 +6222,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6104,7 +6233,6 @@ dependencies = [
  "reth-payload-primitives",
  "reth-payload-validator",
  "reth-primitives",
- "reth-rpc-types-compat",
  "serde",
  "sha2 0.10.8",
 ]
@@ -6112,7 +6240,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -6121,14 +6249,14 @@ dependencies = [
  "auto_impl",
  "dyn-clone",
  "once_cell",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
 ]
 
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6154,7 +6282,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6166,7 +6294,6 @@ dependencies = [
  "arbitrary",
  "derive_more",
  "modular-bitfield",
- "once_cell",
  "rand",
  "reth-codecs",
  "reth-primitives-traits",
@@ -6179,7 +6306,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -6189,7 +6316,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6215,7 +6342,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6236,23 +6363,21 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
  "reth-consensus",
- "reth-prune-types",
  "reth-storage-errors",
- "revm-primitives",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "reth-execution-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6270,7 +6395,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6307,7 +6432,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6322,7 +6447,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "serde",
  "serde_json",
@@ -6332,7 +6457,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6359,7 +6484,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6380,11 +6505,11 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "bitflags 2.8.0",
  "byteorder",
- "dashmap",
+ "dashmap 6.1.0",
  "derive_more",
  "indexmap 2.7.1",
  "parking_lot",
@@ -6397,7 +6522,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "bindgen",
  "cc",
@@ -6406,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "futures",
  "metrics",
@@ -6418,7 +6543,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-primitives",
 ]
@@ -6426,7 +6551,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -6440,7 +6565,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6479,7 +6604,7 @@ dependencies = [
  "reth-tasks",
  "reth-tokio-util",
  "reth-transaction-pool",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "schnellru",
  "secp256k1",
  "serde",
@@ -6494,7 +6619,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
@@ -6517,7 +6642,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6528,9 +6653,9 @@ dependencies = [
  "parking_lot",
  "reth-consensus",
  "reth-eth-wire-types",
+ "reth-ethereum-primitives",
  "reth-network-peers",
  "reth-network-types",
- "reth-primitives",
  "reth-primitives-traits",
  "reth-storage-errors",
  "tokio",
@@ -6540,7 +6665,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6555,7 +6680,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -6569,7 +6694,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6586,10 +6711,11 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
+ "reth-basic-payload-builder",
  "reth-consensus",
  "reth-db-api",
  "reth-engine-primitives",
@@ -6597,6 +6723,7 @@ dependencies = [
  "reth-network-api",
  "reth-node-core",
  "reth-node-types",
+ "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-provider",
@@ -6607,7 +6734,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6619,6 +6746,7 @@ dependencies = [
  "futures",
  "jsonrpsee",
  "rayon",
+ "reth-basic-payload-builder",
  "reth-chain-state",
  "reth-chainspec",
  "reth-cli-util",
@@ -6668,7 +6796,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6717,10 +6845,9 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "eyre",
- "reth-basic-payload-builder",
  "reth-chainspec",
  "reth-consensus",
  "reth-ethereum-consensus",
@@ -6732,7 +6859,6 @@ dependencies = [
  "reth-network",
  "reth-node-api",
  "reth-node-builder",
- "reth-payload-builder",
  "reth-provider",
  "reth-revm",
  "reth-rpc",
@@ -6745,7 +6871,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6769,7 +6895,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "eyre",
  "http",
@@ -6791,7 +6917,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -6804,7 +6930,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6826,11 +6952,10 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types",
- "async-trait",
  "futures-util",
  "metrics",
  "reth-chain-state",
@@ -6847,10 +6972,8 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
- "alloy-rpc-types-engine",
- "async-trait",
  "pin-project",
  "reth-payload-primitives",
  "tokio",
@@ -6861,39 +6984,30 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
+ "auto_impl",
  "op-alloy-rpc-types-engine",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
  "reth-primitives",
- "revm-primitives",
  "serde",
  "thiserror 2.0.11",
  "tokio",
 ]
 
 [[package]]
-name = "reth-payload-util"
-version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
-dependencies = [
- "alloy-consensus",
- "alloy-primitives",
- "reth-primitives",
-]
-
-[[package]]
 name = "reth-payload-validator"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-rpc-types",
  "reth-chainspec",
+ "reth-engine-primitives",
  "reth-primitives",
  "reth-primitives-traits",
 ]
@@ -6901,25 +7015,22 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives",
  "arbitrary",
  "c-kzg",
- "derive_more",
  "once_cell",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "reth-static-file-types",
- "serde",
 ]
 
 [[package]]
 name = "reth-primitives-traits"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6950,14 +7061,14 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
- "dashmap",
+ "dashmap 6.1.0",
  "eyre",
  "itertools 0.13.0",
  "metrics",
@@ -6995,7 +7106,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7015,7 +7126,7 @@ dependencies = [
  "reth-prune-types",
  "reth-static-file-types",
  "reth-tokio-util",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "thiserror 2.0.11",
  "tokio",
  "tracing",
@@ -7024,7 +7135,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -7038,7 +7149,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7052,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7122,7 +7233,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
@@ -7147,8 +7258,10 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
+ "alloy-network",
+ "alloy-provider",
  "http",
  "jsonrpsee",
  "metrics",
@@ -7183,7 +7296,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7199,8 +7312,8 @@ dependencies = [
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
+ "reth-primitives-traits",
  "reth-rpc-api",
- "reth-rpc-types-compat",
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
@@ -7213,7 +7326,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7257,7 +7370,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7300,7 +7413,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -7314,7 +7427,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7330,12 +7443,10 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types-compat"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
  "alloy-primitives",
- "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "jsonrpsee-types",
  "reth-primitives",
@@ -7346,7 +7457,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7388,7 +7499,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7415,7 +7526,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -7429,7 +7540,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -7450,7 +7561,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -7462,7 +7573,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7487,7 +7598,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7503,7 +7614,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -7521,7 +7632,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -7531,7 +7642,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "clap",
  "eyre",
@@ -7546,7 +7657,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7565,14 +7676,13 @@ dependencies = [
  "reth-execution-types",
  "reth-fs-util",
  "reth-metrics",
- "reth-payload-util",
  "reth-primitives",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
  "revm-interpreter",
  "revm-primitives",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "schnellru",
  "serde",
  "smallvec",
@@ -7585,7 +7695,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7595,7 +7705,6 @@ dependencies = [
  "auto_impl",
  "itertools 0.13.0",
  "metrics",
- "rayon",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
@@ -7611,7 +7720,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7626,8 +7735,10 @@ dependencies = [
  "itertools 0.13.0",
  "nybbles",
  "plain_hasher",
+ "rayon",
  "reth-codecs",
  "reth-primitives-traits",
+ "revm",
  "serde",
  "serde_with",
 ]
@@ -7635,7 +7746,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7656,7 +7767,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7679,7 +7790,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7694,7 +7805,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth?rev=4eb65250a7430bf8699e1128f472b9cf842a54ae#4eb65250a7430bf8699e1128f472b9cf842a54ae"
+source = "git+https://github.com/paradigmxyz/reth?rev=2933ec72987df396d1d3411323dc2260b522aab2#2933ec72987df396d1d3411323dc2260b522aab2"
 dependencies = [
  "zstd",
 ]
@@ -7740,6 +7851,7 @@ dependencies = [
  "reth-evm",
  "reth-evm-ethereum",
  "reth-network-peers",
+ "reth-node-builder",
  "reth-node-ethereum",
  "reth-primitives",
  "reth-primitives-traits",
@@ -7785,9 +7897,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc873bc873e12a1723493e1a35804fa79b673a0bfb1c19cfee659d46def8be42"
+checksum = "6d87cdf1c0d878b48423f8a86232950657abaf72a2d0d14af609467542313b1a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -7798,6 +7910,7 @@ dependencies = [
  "boa_gc",
  "colorchoice",
  "revm",
+ "serde",
  "serde_json",
  "thiserror 2.0.11",
 ]
@@ -8002,9 +8115,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 dependencies = [
  "rand",
 ]
@@ -8048,9 +8161,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
+version = "0.23.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
 dependencies = [
  "log",
  "once_cell",
@@ -8341,7 +8454,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -8405,7 +8518,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -8577,6 +8690,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
+name = "skeptic"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
+dependencies = [
+ "bytecount",
+ "cargo_metadata 0.14.2",
+ "error-chain",
+ "glob",
+ "pulldown-cmark",
+ "tempfile",
+ "walkdir",
+]
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8692,7 +8820,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -8727,9 +8855,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8738,14 +8866,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84e4d83a0a6704561302b917a932484e1cae2d8c6354c64be8b7bac1c1fe057"
+checksum = "b7f6a4b9002584ea56d0a19713b65da44cbbf6070aca9ae0360577cba5c4db68"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -8765,7 +8893,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -8839,7 +8967,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -8850,7 +8978,7 @@ checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -9017,7 +9145,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -9044,9 +9172,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+checksum = "be4bf6fecd69fcdede0ec680aaf474cdab988f9de6bc73d3758f0160e3b7025a"
 dependencies = [
  "futures-util",
  "log",
@@ -9075,9 +9203,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -9096,9 +9224,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
 dependencies = [
  "indexmap 2.7.1",
  "serde",
@@ -9218,7 +9346,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -9317,6 +9445,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9324,9 +9458,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+checksum = "413083a99c579593656008130e29255e54dcaae495be556cc26888f211648c24"
 dependencies = [
  "byteorder",
  "bytes",
@@ -9338,7 +9472,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "utf-8",
 ]
 
@@ -9491,11 +9625,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
 ]
 
 [[package]]
@@ -9511,7 +9645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.18.1",
  "cfg-if",
  "regex",
  "rustversion",
@@ -9532,14 +9666,14 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "wait-timeout"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
@@ -9600,7 +9734,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -9635,7 +9769,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9685,9 +9819,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -9791,7 +9925,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -9802,7 +9936,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -9813,7 +9947,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -9824,7 +9958,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -10016,9 +10150,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.25"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad699df48212c6cc6eb4435f35500ac6fd3b9913324f938aea302022ce19d310"
+checksum = "86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f"
 dependencies = [
  "memchr",
 ]
@@ -10108,7 +10242,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "synstructure",
 ]
 
@@ -10130,7 +10264,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -10150,7 +10284,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "synstructure",
 ]
 
@@ -10171,7 +10305,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -10193,7 +10327,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,43 +12,44 @@ name = "reth"
 path = "src/main.rs"
 
 [dependencies]
-reth = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-# reth-auto-seal-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae", features = [
+reth = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+# reth-auto-seal-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2", features = [
     "test-utils",
 ] }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-stages-api = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-stages-types = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "4eb65250a7430bf8699e1128f472b9cf842a54ae" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-stages-api = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-stages-types = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "2933ec72987df396d1d3411323dc2260b522aab2" }
 eyre = "0.6"
 clap = { version = "4.5.6", features = ["derive"] }
 derive_more = { version = "1", default-features = false, features = ["full"] }
@@ -58,7 +59,7 @@ revm = { version = "19.4.0", features = ["std"], default-features = false }
 revm-primitives = { version = "15.1.0", features = [
     "std",
 ], default-features = false }
-revm-inspectors = "0.14.1"
+revm-inspectors = "0.15.0"
 
 serde = { version = "1.0", features = ["derive"], default-features = false }
 serde_json = "1.0.94"
@@ -76,11 +77,11 @@ alloy-rlp = { version = "0.3.10", default-features = false }
 alloy-sol-types = "0.8.15"
 alloy-trie = { version = "0.7", default-features = false }
 
-alloy-consensus = { version = "0.9.2", default-features = false }
-alloy-eips = { version = "0.9.2", default-features = false }
-alloy-genesis = { version = "0.9.2", default-features = false }
-alloy-sol-macro = "0.8.9"
-alloy-serde = { version = "0.9.2", default-features = false }
+alloy-consensus = { version = "0.11.0", default-features = false }
+alloy-eips = { version = "0.11.0", default-features = false }
+alloy-genesis = { version = "0.11.0", default-features = false }
+alloy-sol-macro = "0.8.20"
+alloy-serde = { version = "0.11.0", default-features = false }
 rayon = "1.7"
 
 tracing = "0.1.0"

--- a/src/blobs.rs
+++ b/src/blobs.rs
@@ -21,6 +21,14 @@ pub const GNOSIS_BLOB_SCHEDULE: HardforkBlobParams = HardforkBlobParams {
     prague: PRAGUE_BLOB_PARAMS,
 };
 
+pub fn get_blob_params(is_prague: bool) -> BlobParams {
+    if is_prague {
+        PRAGUE_BLOB_PARAMS
+    } else {
+        CANCUN_BLOB_PARAMS
+    }
+}
+
 #[inline]
 pub fn calc_blob_gasprice(excess_blob_gas: u64, is_prague: bool) -> u128 {
     fake_exponential(

--- a/src/evm_config.rs
+++ b/src/evm_config.rs
@@ -16,7 +16,7 @@ use revm_primitives::{
 };
 use std::{convert::Infallible, sync::Arc};
 
-use crate::blobs::{next_blob_gas_and_price, CANCUN_BLOB_PARAMS, PRAGUE_BLOB_PARAMS};
+use crate::blobs::{get_blob_params, next_blob_gas_and_price};
 use crate::spec::GnosisChainSpec;
 
 /// Reward beneficiary with gas fee.
@@ -230,11 +230,7 @@ impl ConfigureEvmEnv for GnosisEvmConfig {
             parent.number() + 1,
         );
 
-        let blob_params = if spec_id >= SpecId::PRAGUE {
-            PRAGUE_BLOB_PARAMS
-        } else {
-            CANCUN_BLOB_PARAMS
-        };
+        let blob_params = get_blob_params(spec_id >= SpecId::PRAGUE);
 
         // if the parent block did not have excess blob gas (i.e. it was pre-cancun), but it is
         // cancun now, we need to set the excess blob gas to the default value(0)

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -331,7 +331,7 @@ where
             tx_type: tx.tx_type(),
             success: result.is_success(),
             cumulative_gas_used,
-            logs: result.into_logs().into_iter().map(Into::into).collect(),
+            logs: result.into_logs().into_iter().collect(),
             ..Default::default()
         });
 
@@ -500,8 +500,8 @@ where
         gas_used: cumulative_gas_used,
         extra_data: builder_config.extra_data,
         parent_beacon_block_root: attributes.parent_beacon_block_root,
-        blob_gas_used: blob_gas_used.map(Into::into),
-        excess_blob_gas: excess_blob_gas.map(Into::into),
+        blob_gas_used: blob_gas_used,
+        excess_blob_gas: excess_blob_gas,
         requests_hash,
     };
 

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -166,6 +166,7 @@ where
 /// and configuration, this function creates a transaction payload. Returns
 /// a result indicating success with the payload or an error in case of failure.
 #[inline]
+#[allow(clippy::too_many_arguments)]
 pub fn default_ethereum_payload<EvmConfig, Pool, Client, F>(
     evm_config: EvmConfig,
     client: Client,
@@ -417,7 +418,7 @@ where
     let requests_hash = requests.as_ref().map(|requests| requests.requests_hash());
     let execution_outcome = ExecutionOutcome::new(
         db.take_bundle(),
-        vec![receipts].into(),
+        vec![receipts],
         block_number,
         vec![requests.clone().unwrap_or_default()],
     );
@@ -500,8 +501,8 @@ where
         gas_used: cumulative_gas_used,
         extra_data: builder_config.extra_data,
         parent_beacon_block_root: attributes.parent_beacon_block_root,
-        blob_gas_used: blob_gas_used,
-        excess_blob_gas: excess_blob_gas,
+        blob_gas_used,
+        excess_blob_gas,
         requests_hash,
     };
 

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -35,11 +35,7 @@ use revm::{
 use revm_primitives::{ResultAndState, U256};
 use tracing::{debug, trace, warn};
 
-use crate::{
-    blobs::{CANCUN_BLOB_PARAMS, PRAGUE_BLOB_PARAMS},
-    gnosis::apply_post_block_system_calls,
-    spec::GnosisChainSpec,
-};
+use crate::{blobs::get_blob_params, gnosis::apply_post_block_system_calls, spec::GnosisChainSpec};
 
 type BestTransactionsIter<Pool> = Box<
     dyn BestTransactions<Item = Arc<ValidPoolTransaction<<Pool as TransactionPool>::Transaction>>>,
@@ -466,12 +462,8 @@ where
             .map_err(PayloadBuilderError::other)?;
 
         excess_blob_gas = if chain_spec.is_cancun_active_at_timestamp(parent_header.timestamp) {
-            let blob_params = if chain_spec.is_prague_active_at_timestamp(attributes.timestamp) {
-                PRAGUE_BLOB_PARAMS
-            } else {
-                // cancun
-                CANCUN_BLOB_PARAMS
-            };
+            let blob_params =
+                get_blob_params(chain_spec.is_prague_active_at_timestamp(attributes.timestamp));
             parent_header.next_block_excess_blob_gas(blob_params)
         } else {
             // for the first post-fork block, both parent.blob_gas_used and

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,0 +1,534 @@
+use std::sync::Arc;
+
+use alloy_consensus::{
+    proofs::calculate_withdrawals_root, Header, Transaction, EMPTY_OMMER_ROOT_HASH,
+};
+use alloy_eips::{
+    eip4844::MAX_DATA_GAS_PER_BLOCK, eip6110, eip7685::Requests, merge::BEACON_NONCE, Typed2718,
+};
+use alloy_primitives::Address;
+use reth_basic_payload_builder::{
+    is_better_payload, BuildArguments, BuildOutcome, PayloadBuilder, PayloadConfig,
+};
+use reth_chainspec::EthereumHardforks;
+use reth_errors::RethError;
+use reth_ethereum_engine_primitives::{EthBuiltPayload, EthPayloadBuilderAttributes};
+use reth_ethereum_payload_builder::EthereumBuilderConfig;
+use reth_evm::{
+    system_calls::SystemCaller, ConfigureEvm, ConfigureEvmEnv, Evm, EvmEnv, EvmError,
+    InvalidTxError, NextBlockEnvAttributes,
+};
+use reth_evm_ethereum::eip6110::parse_deposits_from_receipts;
+use reth_node_builder::{PayloadBuilderAttributes, PayloadBuilderError};
+use reth_primitives::{Block, BlockBody, InvalidTransactionError, Receipt, TransactionSigned};
+use reth_primitives_traits::{proofs, Block as _, SignedTransaction};
+use reth_provider::{ChainSpecProvider, ExecutionOutcome, StateProviderFactory};
+use reth_revm::database::StateProviderDatabase;
+use reth_transaction_pool::{
+    error::InvalidPoolTransactionError, BestTransactions, BestTransactionsAttributes,
+    PoolTransaction, TransactionPool, ValidPoolTransaction,
+};
+use revm::{
+    db::{states::bundle_state::BundleRetention, State},
+    DatabaseCommit,
+};
+use revm_primitives::{ResultAndState, U256};
+use tracing::{debug, trace, warn};
+
+use crate::{
+    blobs::{CANCUN_BLOB_PARAMS, PRAGUE_BLOB_PARAMS},
+    gnosis::apply_post_block_system_calls,
+    spec::GnosisChainSpec,
+};
+
+type BestTransactionsIter<Pool> = Box<
+    dyn BestTransactions<Item = Arc<ValidPoolTransaction<<Pool as TransactionPool>::Transaction>>>,
+>;
+
+/// Gnosis payload builder
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GnosisPayloadBuilder<Pool, Client, GnosisEvmConfig> {
+    /// Client providing access to node state.
+    client: Client,
+    /// Transaction pool.
+    pool: Pool,
+    /// The type responsible for creating the evm.
+    evm_config: GnosisEvmConfig,
+    /// AuRa BlockRewards contract address for its system call
+    block_rewards_contract: Address,
+    /// Payload builder configuration.
+    builder_config: EthereumBuilderConfig,
+}
+
+impl<Pool, Client, EvmConfig> GnosisPayloadBuilder<Pool, Client, EvmConfig>
+where
+    EvmConfig: ConfigureEvmEnv<Header = Header>,
+{
+    pub const fn new(
+        client: Client,
+        pool: Pool,
+        evm_config: EvmConfig,
+        block_rewards_contract: Address,
+        builder_config: EthereumBuilderConfig,
+    ) -> Self {
+        Self {
+            client,
+            pool,
+            evm_config,
+            block_rewards_contract,
+            builder_config,
+        }
+    }
+}
+
+impl<Pool, Client, EvmConfig> GnosisPayloadBuilder<Pool, Client, EvmConfig>
+where
+    EvmConfig: ConfigureEvmEnv<Header = Header>,
+{
+    /// Returns the configured [`EvmEnv`] for the targeted payload
+    /// (that has the `parent` as its parent).
+    fn evm_env(
+        &self,
+        config: &PayloadConfig<EthPayloadBuilderAttributes>,
+        parent: &Header,
+    ) -> Result<EvmEnv<EvmConfig::Spec>, EvmConfig::Error> {
+        let next_attributes = NextBlockEnvAttributes {
+            timestamp: config.attributes.timestamp(),
+            suggested_fee_recipient: config.attributes.suggested_fee_recipient(),
+            prev_randao: config.attributes.prev_randao(),
+            gas_limit: self.builder_config.gas_limit(parent.gas_limit),
+        };
+        self.evm_config.next_evm_env(parent, next_attributes)
+    }
+}
+
+// Default implementation of [PayloadBuilder] for unit type
+impl<Pool, Client, EvmConfig> PayloadBuilder for GnosisPayloadBuilder<Pool, Client, EvmConfig>
+where
+    EvmConfig: ConfigureEvm<Header = Header, Transaction = TransactionSigned>,
+    Client: StateProviderFactory + ChainSpecProvider<ChainSpec = GnosisChainSpec> + Clone,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
+{
+    type Attributes = EthPayloadBuilderAttributes;
+    type BuiltPayload = EthBuiltPayload;
+
+    fn try_build(
+        &self,
+        args: BuildArguments<EthPayloadBuilderAttributes, EthBuiltPayload>,
+    ) -> Result<BuildOutcome<EthBuiltPayload>, PayloadBuilderError> {
+        let evm_env = self
+            .evm_env(&args.config, &args.config.parent_header)
+            .map_err(PayloadBuilderError::other)?;
+
+        default_ethereum_payload(
+            self.evm_config.clone(),
+            self.client.clone(),
+            self.pool.clone(),
+            self.builder_config.clone(),
+            args,
+            evm_env,
+            self.block_rewards_contract,
+            |attributes| self.pool.best_transactions_with_attributes(attributes),
+        )
+    }
+
+    fn build_empty_payload(
+        &self,
+        config: PayloadConfig<Self::Attributes>,
+    ) -> Result<EthBuiltPayload, PayloadBuilderError> {
+        let args = BuildArguments::new(Default::default(), config, Default::default(), None);
+
+        let evm_env = self
+            .evm_env(&args.config, &args.config.parent_header)
+            .map_err(PayloadBuilderError::other)?;
+
+        default_ethereum_payload(
+            self.evm_config.clone(),
+            self.client.clone(),
+            self.pool.clone(),
+            self.builder_config.clone(),
+            args,
+            evm_env,
+            self.block_rewards_contract,
+            |attributes| self.pool.best_transactions_with_attributes(attributes),
+        )?
+        .into_payload()
+        .ok_or_else(|| PayloadBuilderError::MissingPayload)
+    }
+}
+
+/// Constructs an Ethereum transaction payload from the transactions sent through the
+/// Payload attributes by the sequencer. If the `no_tx_pool` argument is passed in
+/// the payload attributes, the transaction pool will be ignored and the only transactions
+/// included in the payload will be those sent through the attributes.
+///
+/// Given build arguments including an Ethereum client, transaction pool,
+/// and configuration, this function creates a transaction payload. Returns
+/// a result indicating success with the payload or an error in case of failure.
+#[inline]
+pub fn default_ethereum_payload<EvmConfig, Pool, Client, F>(
+    evm_config: EvmConfig,
+    client: Client,
+    pool: Pool,
+    builder_config: EthereumBuilderConfig,
+    args: BuildArguments<EthPayloadBuilderAttributes, EthBuiltPayload>,
+    evm_env: EvmEnv<EvmConfig::Spec>,
+    block_rewards_contract: Address,
+    best_txs: F,
+) -> Result<BuildOutcome<EthBuiltPayload>, PayloadBuilderError>
+where
+    EvmConfig: ConfigureEvm<Header = Header, Transaction = TransactionSigned>,
+    Client: StateProviderFactory + ChainSpecProvider<ChainSpec = GnosisChainSpec>,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
+    F: FnOnce(BestTransactionsAttributes) -> BestTransactionsIter<Pool>,
+{
+    let BuildArguments {
+        mut cached_reads,
+        config,
+        cancel,
+        best_payload,
+    } = args;
+    let chain_spec = client.chain_spec();
+    let state_provider = client.state_by_block_hash(config.parent_header.hash())?;
+    let state = StateProviderDatabase::new(state_provider);
+    let mut db = State::builder()
+        .with_database(cached_reads.as_db_mut(state))
+        .with_bundle_update()
+        .build();
+    let PayloadConfig {
+        parent_header,
+        attributes,
+    } = config;
+
+    debug!(target: "payload_builder", id=%attributes.id, parent_header = ?parent_header.hash(), parent_number = parent_header.number, "building new payload");
+    let mut cumulative_gas_used = 0;
+    let mut sum_blob_gas_used = 0;
+    let block_gas_limit: u64 = evm_env.block_env.gas_limit.to::<u64>();
+    let base_fee = evm_env.block_env.basefee.to::<u64>();
+
+    let mut executed_txs = Vec::new();
+
+    let mut best_txs = best_txs(BestTransactionsAttributes::new(
+        base_fee,
+        evm_env
+            .block_env
+            .get_blob_gasprice()
+            .map(|gasprice| gasprice as u64),
+    ));
+    let mut total_fees = U256::ZERO;
+
+    let block_number = evm_env.block_env.number.to::<u64>();
+    let beneficiary = evm_env.block_env.coinbase;
+
+    let mut system_caller = SystemCaller::new(evm_config.clone(), chain_spec.clone());
+
+    let mut evm = evm_config.evm_with_env(&mut db, evm_env);
+
+    system_caller
+        .apply_pre_execution_changes(&parent_header, &mut evm)
+        .map_err(|err| {
+            warn!(target: "payload_builder",
+                parent_hash=%parent_header.hash(),
+                %err,
+                "failed to apply pre-execution changes for payload"
+            );
+            PayloadBuilderError::Internal(err.into())
+        })?;
+
+    let mut receipts = Vec::new();
+    while let Some(pool_tx) = best_txs.next() {
+        // ensure we still have capacity for this transaction
+        if cumulative_gas_used + pool_tx.gas_limit() > block_gas_limit {
+            // we can't fit this transaction into the block, so we need to mark it as invalid
+            // which also removes all dependent transaction from the iterator before we can
+            // continue
+            best_txs.mark_invalid(
+                &pool_tx,
+                InvalidPoolTransactionError::ExceedsGasLimit(pool_tx.gas_limit(), block_gas_limit),
+            );
+            continue;
+        }
+
+        // check if the job was cancelled, if so we can exit early
+        if cancel.is_cancelled() {
+            return Ok(BuildOutcome::Cancelled);
+        }
+
+        // convert tx to a signed transaction
+        let tx = pool_tx.to_consensus();
+
+        // There's only limited amount of blob space available per block, so we need to check if
+        // the EIP-4844 can still fit in the block
+        if let Some(blob_tx) = tx.as_eip4844() {
+            let tx_blob_gas = blob_tx.blob_gas();
+            if sum_blob_gas_used + tx_blob_gas > MAX_DATA_GAS_PER_BLOCK {
+                // we can't fit this _blob_ transaction into the block, so we mark it as
+                // invalid, which removes its dependent transactions from
+                // the iterator. This is similar to the gas limit condition
+                // for regular transactions above.
+                trace!(target: "payload_builder", tx=?tx.hash(), ?sum_blob_gas_used, ?tx_blob_gas, "skipping blob transaction because it would exceed the max data gas per block");
+                best_txs.mark_invalid(
+                    &pool_tx,
+                    InvalidPoolTransactionError::ExceedsGasLimit(
+                        tx_blob_gas,
+                        MAX_DATA_GAS_PER_BLOCK,
+                    ),
+                );
+                continue;
+            }
+        }
+
+        // Configure the environment for the tx.
+        let tx_env = evm_config.tx_env(tx.tx(), tx.signer());
+
+        let ResultAndState { result, state } = match evm.transact(tx_env) {
+            Ok(res) => res,
+            Err(err) => {
+                if let Some(err) = err.as_invalid_tx_err() {
+                    if err.is_nonce_too_low() {
+                        // if the nonce is too low, we can skip this transaction
+                        trace!(target: "payload_builder", %err, ?tx, "skipping nonce too low transaction");
+                    } else {
+                        // if the transaction is invalid, we can skip it and all of its
+                        // descendants
+                        trace!(target: "payload_builder", %err, ?tx, "skipping invalid transaction and its descendants");
+                        best_txs.mark_invalid(
+                            &pool_tx,
+                            InvalidPoolTransactionError::Consensus(
+                                InvalidTransactionError::TxTypeNotSupported,
+                            ),
+                        );
+                    }
+                    continue;
+                }
+                // this is an error that we should treat as fatal for this attempt
+                return Err(PayloadBuilderError::evm(err));
+            }
+        };
+
+        // commit changes
+        evm.db_mut().commit(state);
+
+        // add to the total blob gas used if the transaction successfully executed
+        if let Some(blob_tx) = tx.as_eip4844() {
+            let tx_blob_gas = blob_tx.blob_gas();
+            sum_blob_gas_used += tx_blob_gas;
+
+            // if we've reached the max data gas per block, we can skip blob txs entirely
+            if sum_blob_gas_used == MAX_DATA_GAS_PER_BLOCK {
+                best_txs.skip_blobs();
+            }
+        }
+
+        let gas_used = result.gas_used();
+
+        // add gas used by the transaction to cumulative gas used, before creating the receipt
+        cumulative_gas_used += gas_used;
+
+        // Push transaction changeset and calculate header bloom filter for receipt.
+        #[allow(clippy::needless_update)] // side-effect of optimism fields
+        receipts.push(Receipt {
+            tx_type: tx.tx_type(),
+            success: result.is_success(),
+            cumulative_gas_used,
+            logs: result.into_logs().into_iter().map(Into::into).collect(),
+            ..Default::default()
+        });
+
+        // update add to total fees
+        let miner_fee = tx
+            .effective_tip_per_gas(base_fee)
+            .expect("fee is always valid; execution succeeded");
+        total_fees += U256::from(miner_fee) * U256::from(gas_used);
+
+        // append transaction to the block body
+        executed_txs.push(tx.into_tx());
+    }
+
+    // check if we have a better block
+    if !is_better_payload(best_payload.as_ref(), total_fees) {
+        // Release db
+        drop(evm);
+
+        // can skip building the block
+        return Ok(BuildOutcome::Aborted {
+            fees: total_fees,
+            cached_reads,
+        });
+    }
+
+    // let mut evm = evm_config.evm_with_env(&mut db, env);
+
+    // < GNOSIS SPECIFIC
+    let (balance_increments, _requests) = apply_post_block_system_calls(
+        &chain_spec,
+        // &evm_config,
+        block_rewards_contract,
+        attributes.timestamp,
+        Some(&attributes.withdrawals),
+        attributes.suggested_fee_recipient,
+        &mut evm,
+    )
+    .map_err(|err| PayloadBuilderError::Internal(err.into()))?;
+    // GNOSIS SPECIFIC >
+
+    evm.db_mut()
+        .increment_balances(balance_increments)
+        .map_err(|err| {
+            warn!(target: "payload_builder",
+                parent_hash=%parent_header.hash(),
+                %err,
+                "failed to increment balances for payload"
+            );
+            PayloadBuilderError::Internal(err.into())
+        })?;
+
+    // calculate the requests and the requests root
+    let requests = if chain_spec.is_prague_active_at_timestamp(attributes.timestamp) {
+        let deposit_requests = parse_deposits_from_receipts(&chain_spec, receipts.iter())
+            .map_err(|err| PayloadBuilderError::Internal(RethError::Execution(err.into())))?;
+
+        let mut requests = Requests::default();
+
+        if !deposit_requests.is_empty() {
+            requests.push_request_with_type(eip6110::DEPOSIT_REQUEST_TYPE, deposit_requests);
+        }
+
+        requests.extend(
+            system_caller
+                .apply_post_execution_changes(&mut evm)
+                .map_err(|err| PayloadBuilderError::Internal(err.into()))?,
+        );
+
+        Some(requests)
+    } else {
+        None
+    };
+
+    // Release db
+    drop(evm);
+
+    let withdrawals_root = Some(calculate_withdrawals_root(&attributes.withdrawals));
+
+    // merge all transitions into bundle state, this would apply the withdrawal balance changes
+    // and 4788 contract call
+    db.merge_transitions(BundleRetention::Reverts);
+
+    let requests_hash = requests.as_ref().map(|requests| requests.requests_hash());
+    let execution_outcome = ExecutionOutcome::new(
+        db.take_bundle(),
+        vec![receipts].into(),
+        block_number,
+        vec![requests.clone().unwrap_or_default()],
+    );
+    let receipts_root = execution_outcome
+        .ethereum_receipts_root(block_number)
+        .expect("Number is in range");
+    let logs_bloom = execution_outcome
+        .block_logs_bloom(block_number)
+        .expect("Number is in range");
+
+    // calculate the state root
+    let hashed_state = db.database.db.hashed_post_state(execution_outcome.state());
+    let (state_root, _) = {
+        db.database
+            .inner()
+            .state_root_with_updates(hashed_state)
+            .inspect_err(|err| {
+                warn!(target: "payload_builder",
+                    parent_hash=%parent_header.hash(),
+                    %err,
+                    "failed to calculate state root for payload"
+                );
+            })?
+    };
+
+    // create the block header
+    let transactions_root = proofs::calculate_transaction_root(&executed_txs);
+
+    // initialize empty blob sidecars at first. If cancun is active then this will
+    let mut blob_sidecars = Vec::new();
+    let mut excess_blob_gas = None;
+    let mut blob_gas_used = None;
+
+    // only determine cancun fields when active
+    if chain_spec.is_cancun_active_at_timestamp(attributes.timestamp) {
+        // grab the blob sidecars from the executed txs
+        blob_sidecars = pool
+            .get_all_blobs_exact(
+                executed_txs
+                    .iter()
+                    .filter(|tx| tx.is_eip4844())
+                    .map(|tx| *tx.tx_hash())
+                    .collect(),
+            )
+            .map_err(PayloadBuilderError::other)?;
+
+        excess_blob_gas = if chain_spec.is_cancun_active_at_timestamp(parent_header.timestamp) {
+            let blob_params = if chain_spec.is_prague_active_at_timestamp(attributes.timestamp) {
+                PRAGUE_BLOB_PARAMS
+            } else {
+                // cancun
+                CANCUN_BLOB_PARAMS
+            };
+            parent_header.next_block_excess_blob_gas(blob_params)
+        } else {
+            // for the first post-fork block, both parent.blob_gas_used and
+            // parent.excess_blob_gas are evaluated as 0
+            Some(alloy_eips::eip4844::calc_excess_blob_gas(0, 0))
+        };
+
+        blob_gas_used = Some(sum_blob_gas_used);
+    }
+
+    let header = Header {
+        parent_hash: parent_header.hash(),
+        ommers_hash: EMPTY_OMMER_ROOT_HASH,
+        beneficiary,
+        state_root,
+        transactions_root,
+        receipts_root,
+        withdrawals_root,
+        logs_bloom,
+        timestamp: attributes.timestamp,
+        mix_hash: attributes.prev_randao,
+        nonce: BEACON_NONCE.into(),
+        base_fee_per_gas: Some(base_fee),
+        number: parent_header.number + 1,
+        gas_limit: block_gas_limit,
+        difficulty: U256::ZERO,
+        gas_used: cumulative_gas_used,
+        extra_data: builder_config.extra_data,
+        parent_beacon_block_root: attributes.parent_beacon_block_root,
+        blob_gas_used: blob_gas_used.map(Into::into),
+        excess_blob_gas: excess_blob_gas.map(Into::into),
+        requests_hash,
+    };
+
+    let withdrawals = chain_spec
+        .is_shanghai_active_at_timestamp(attributes.timestamp)
+        .then(|| attributes.withdrawals.clone());
+
+    // seal the block
+    let block = Block {
+        header,
+        body: BlockBody {
+            transactions: executed_txs,
+            ommers: vec![],
+            withdrawals,
+        },
+    };
+
+    let sealed_block = Arc::new(block.seal_slow());
+    debug!(target: "payload_builder", id=%attributes.id, sealed_block_header = ?sealed_block.sealed_header(), "sealed built block");
+
+    let mut payload = EthBuiltPayload::new(attributes.id, sealed_block, total_fees, requests);
+
+    // extend the payload with the blob sidecars from the executed txs
+    payload.extend_sidecars(blob_sidecars.into_iter().map(Arc::unwrap_or_clone));
+
+    Ok(BuildOutcome::Better {
+        payload,
+        cached_reads,
+    })
+}

--- a/src/payload_builder.rs
+++ b/src/payload_builder.rs
@@ -19,7 +19,7 @@ use crate::{evm_config::GnosisEvmConfig, spec::GnosisChainSpec};
 pub struct GnosisPayloadBuilder;
 
 impl GnosisPayloadBuilder {
-    /// A helper method initializing [`reth_ethereum_payload_builder::GnosisPayloadBuilder`] with
+    /// A helper method initializing [`crate::payload::GnosisPayloadBuilder`] with
     /// the given EVM config.
     pub fn build<Types, Node, Evm, Pool>(
         &self,

--- a/src/payload_builder.rs
+++ b/src/payload_builder.rs
@@ -1,630 +1,90 @@
-use std::sync::Arc;
-
-use alloy_consensus::{
-    proofs::calculate_withdrawals_root, Header, Transaction, Typed2718, EMPTY_OMMER_ROOT_HASH,
+use reth_ethereum_engine_primitives::{
+    EthBuiltPayload, EthPayloadAttributes, EthPayloadBuilderAttributes,
 };
-use alloy_eips::{
-    eip4844::MAX_DATA_GAS_PER_BLOCK, eip6110, eip7685::Requests, merge::BEACON_NONCE,
-};
-use eyre::eyre;
-use reth::{
-    api::{FullNodeTypes, NodeTypesWithEngine},
-    builder::{components::PayloadServiceBuilder, BuilderContext, PayloadBuilderConfig},
-    payload::{
-        EthBuiltPayload, EthPayloadBuilderAttributes, PayloadBuilderAttributes,
-        PayloadBuilderError, PayloadBuilderHandle, PayloadBuilderService,
-    },
-    revm::database::StateProviderDatabase,
-    transaction_pool::{
-        error::InvalidPoolTransactionError, noop::NoopTransactionPool, BestTransactions,
-        BestTransactionsAttributes, PoolTransaction, TransactionPool, ValidPoolTransaction,
-    },
-};
-use reth_basic_payload_builder::{
-    is_better_payload, BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig, BuildArguments,
-    BuildOutcome, PayloadBuilder, PayloadConfig,
-};
-use reth_chainspec::EthereumHardforks;
-use reth_errors::RethError;
 use reth_ethereum_payload_builder::EthereumBuilderConfig;
-use reth_evm::{
-    system_calls::SystemCaller, ConfigureEvm, ConfigureEvmEnv, Evm, EvmEnv, NextBlockEnvAttributes,
+use reth_evm::ConfigureEvmFor;
+use reth_node_builder::{
+    components::PayloadServiceBuilder, BuilderContext, FullNodeTypes, NodeTypesWithEngine,
+    PayloadBuilderConfig, PayloadTypes, PrimitivesTy, TxTy,
 };
-use reth_evm_ethereum::eip6110::parse_deposits_from_receipts;
-use reth_node_ethereum::EthEngineTypes;
-use reth_primitives::{
-    Block, BlockBody, EthPrimitives, InvalidTransactionError, Receipt, TransactionSigned,
-};
-use reth_primitives_traits::{proofs, Block as _, SignedTransaction};
-use reth_provider::{
-    CanonStateSubscriptions, ChainSpecProvider, ExecutionOutcome, StateProviderFactory,
-};
-use revm::{
-    db::{states::bundle_state::BundleRetention, State},
-    DatabaseCommit,
-};
-use revm_primitives::{Address, EVMError, InvalidTransaction, ResultAndState, U256};
-use tracing::{debug, trace, warn};
+use reth_primitives::EthPrimitives;
+use reth_transaction_pool::{PoolTransaction, TransactionPool};
+use revm_primitives::Address;
 
-use crate::{
-    blobs::{CANCUN_BLOB_PARAMS, PRAGUE_BLOB_PARAMS},
-    evm_config::GnosisEvmConfig,
-    gnosis::apply_post_block_system_calls,
-    spec::GnosisChainSpec,
-};
+use crate::{evm_config::GnosisEvmConfig, spec::GnosisChainSpec};
 
-type BestTransactionsIter<Pool> = Box<
-    dyn BestTransactions<Item = Arc<ValidPoolTransaction<<Pool as TransactionPool>::Transaction>>>,
->;
+/// A basic ethereum payload service.
+#[derive(Clone, Default, Debug)]
+#[non_exhaustive]
+pub struct GnosisPayloadBuilder;
 
-/// A basic Gnosis payload service builder
-#[derive(Debug, Default, Clone)]
-pub struct GnosisPayloadServiceBuilder {
-    // The EVM configuration to use for the payload builder.
-}
-
-impl GnosisPayloadServiceBuilder {
-    /// Create a new instance with the given evm config.
-    pub const fn new() -> Self {
-        Self {}
-    }
-}
-
-impl<Node, Pool> PayloadServiceBuilder<Node, Pool> for GnosisPayloadServiceBuilder
-where
-    Node: FullNodeTypes<
-        Types: NodeTypesWithEngine<
-            Engine = EthEngineTypes,
-            ChainSpec = GnosisChainSpec,
-            Primitives = EthPrimitives,
-        >,
-    >,
-    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>
-        + Unpin
-        + 'static,
-{
-    async fn spawn_payload_service(
-        self,
+impl GnosisPayloadBuilder {
+    /// A helper method initializing [`reth_ethereum_payload_builder::GnosisPayloadBuilder`] with
+    /// the given EVM config.
+    pub fn build<Types, Node, Evm, Pool>(
+        &self,
+        evm_config: Evm,
         ctx: &BuilderContext<Node>,
         pool: Pool,
-    ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypesWithEngine>::Engine>> {
+    ) -> eyre::Result<crate::payload::GnosisPayloadBuilder<Pool, Node::Provider, Evm>>
+    where
+        Types: NodeTypesWithEngine<ChainSpec = GnosisChainSpec, Primitives = EthPrimitives>,
+        Node: FullNodeTypes<Types = Types>,
+        Evm: ConfigureEvmFor<PrimitivesTy<Types>>,
+        Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
+            + Unpin
+            + 'static,
+        Types::Engine: PayloadTypes<
+            BuiltPayload = EthBuiltPayload,
+            PayloadAttributes = EthPayloadAttributes,
+            PayloadBuilderAttributes = EthPayloadBuilderAttributes,
+        >,
+    {
         let chain_spec = ctx.chain_spec();
         let block_rewards_contract = chain_spec
             .genesis()
             .config
             .extra_fields
             .get("blockRewardsContract")
-            .ok_or(eyre!("blockRewardsContract not defined"))?;
+            .expect("blockRewardsContract field not found in genesis config");
         let block_rewards_contract: Address =
-            serde_json::from_value(block_rewards_contract.clone())?;
-
-        let collector_address = ctx
-            .config()
-            .chain
-            .genesis()
-            .config
-            .extra_fields
-            .get("eip1559collector")
-            .ok_or(eyre!("no eip1559collector field"))?;
-        let collector_address: Address = serde_json::from_value(collector_address.clone())?;
+            serde_json::from_value(block_rewards_contract.clone())
+                .expect("failed to parse blockRewardsContract field");
 
         let conf = ctx.payload_builder_config();
         let gas_limit = chain_spec.genesis.gas_limit;
-        let payload_builder = GnosisPayloadBuilder::new(
-            GnosisEvmConfig::new(collector_address, chain_spec),
-            EthereumBuilderConfig::new(conf.extra_data_bytes()).with_gas_limit(gas_limit),
-            block_rewards_contract,
-        );
 
-        let payload_job_config = BasicPayloadJobGeneratorConfig::default()
-            .interval(conf.interval())
-            .deadline(conf.deadline())
-            .max_payload_tasks(conf.max_payload_tasks());
-
-        let payload_generator = BasicPayloadJobGenerator::with_builder(
+        Ok(crate::payload::GnosisPayloadBuilder::new(
             ctx.provider().clone(),
             pool,
-            ctx.task_executor().clone(),
-            payload_job_config,
-            payload_builder,
-        );
-        let (payload_service, payload_builder) =
-            PayloadBuilderService::new(payload_generator, ctx.provider().canonical_state_stream());
-
-        ctx.task_executor()
-            .spawn_critical("payload builder service", Box::pin(payload_service));
-
-        Ok(payload_builder)
-    }
-}
-
-/// Ethereum payload builder
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct GnosisPayloadBuilder<GnosisEvmConfig> {
-    /// The type responsible for creating the evm.
-    evm_config: GnosisEvmConfig,
-    /// AuRa BlockRewards contract address for its system call
-    block_rewards_contract: Address,
-    /// Payload builder configuration.
-    builder_config: EthereumBuilderConfig,
-}
-
-impl<EvmConfig> GnosisPayloadBuilder<EvmConfig>
-where
-    EvmConfig: ConfigureEvmEnv<Header = Header>,
-{
-    pub const fn new(
-        evm_config: EvmConfig,
-        builder_config: EthereumBuilderConfig,
-        block_rewards_contract: Address,
-    ) -> Self {
-        Self {
             evm_config,
-            builder_config,
             block_rewards_contract,
-        }
+            EthereumBuilderConfig::new(conf.extra_data_bytes()).with_gas_limit(gas_limit),
+        ))
     }
 }
 
-impl<EvmConfig> GnosisPayloadBuilder<EvmConfig>
+impl<Types, Node, Pool> PayloadServiceBuilder<Node, Pool> for GnosisPayloadBuilder
 where
-    EvmConfig: ConfigureEvmEnv<Header = Header>,
+    Types: NodeTypesWithEngine<ChainSpec = GnosisChainSpec, Primitives = EthPrimitives>,
+    Node: FullNodeTypes<Types = Types>,
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
+        + Unpin
+        + 'static,
+    Types::Engine: PayloadTypes<
+        BuiltPayload = EthBuiltPayload,
+        PayloadAttributes = EthPayloadAttributes,
+        PayloadBuilderAttributes = EthPayloadBuilderAttributes,
+    >,
 {
-    /// Returns the configured [`EvmEnv`] for the targeted payload
-    /// (that has the `parent` as its parent).
-    fn evm_env(
+    type PayloadBuilder =
+        crate::payload::GnosisPayloadBuilder<Pool, Node::Provider, GnosisEvmConfig>;
+
+    async fn build_payload_builder(
         &self,
-        config: &PayloadConfig<EthPayloadBuilderAttributes>,
-        parent: &Header,
-    ) -> Result<EvmEnv<EvmConfig::Spec>, EvmConfig::Error> {
-        let next_attributes = NextBlockEnvAttributes {
-            timestamp: config.attributes.timestamp(),
-            suggested_fee_recipient: config.attributes.suggested_fee_recipient(),
-            prev_randao: config.attributes.prev_randao(),
-            gas_limit: self.builder_config.gas_limit(parent.gas_limit),
-        };
-        self.evm_config.next_evm_env(parent, next_attributes)
+        ctx: &BuilderContext<Node>,
+        pool: Pool,
+    ) -> eyre::Result<Self::PayloadBuilder> {
+        self.build(GnosisEvmConfig::new(ctx.chain_spec()), ctx, pool)
     }
-}
-
-// Default implementation of [PayloadBuilder] for unit type
-impl<EvmConfig, Pool, Client> PayloadBuilder<Pool, Client> for GnosisPayloadBuilder<EvmConfig>
-where
-    EvmConfig: ConfigureEvm<Header = Header, Transaction = TransactionSigned>,
-    Client: StateProviderFactory + ChainSpecProvider<ChainSpec = GnosisChainSpec>,
-    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
-{
-    type Attributes = EthPayloadBuilderAttributes;
-    type BuiltPayload = EthBuiltPayload;
-
-    fn try_build(
-        &self,
-        args: BuildArguments<Pool, Client, EthPayloadBuilderAttributes, EthBuiltPayload>,
-    ) -> Result<BuildOutcome<EthBuiltPayload>, PayloadBuilderError> {
-        let evm_env = self
-            .evm_env(&args.config, &args.config.parent_header)
-            .map_err(PayloadBuilderError::other)?;
-        let pool = args.pool.clone();
-        default_ethereum_payload(
-            self.evm_config.clone(),
-            self.builder_config.clone(),
-            args,
-            evm_env,
-            self.block_rewards_contract,
-            |attributes| pool.best_transactions_with_attributes(attributes),
-        )
-    }
-
-    fn build_empty_payload(
-        &self,
-        client: &Client,
-        config: PayloadConfig<Self::Attributes>,
-    ) -> Result<EthBuiltPayload, PayloadBuilderError> {
-        let args = BuildArguments {
-            client,
-            config,
-            pool: NoopTransactionPool::default(),
-            cached_reads: Default::default(),
-            cancel: Default::default(),
-            best_payload: None,
-        };
-
-        let evm_env = self
-            .evm_env(&args.config, &args.config.parent_header)
-            .map_err(PayloadBuilderError::other)?;
-
-        let pool = args.pool.clone();
-
-        default_ethereum_payload(
-            self.evm_config.clone(),
-            self.builder_config.clone(),
-            args,
-            evm_env,
-            self.block_rewards_contract,
-            |attributes| pool.best_transactions_with_attributes(attributes),
-        )?
-        .into_payload()
-        .ok_or_else(|| PayloadBuilderError::MissingPayload)
-    }
-}
-
-/// Constructs an Ethereum transaction payload from the transactions sent through the
-/// Payload attributes by the sequencer. If the `no_tx_pool` argument is passed in
-/// the payload attributes, the transaction pool will be ignored and the only transactions
-/// included in the payload will be those sent through the attributes.
-///
-/// Given build arguments including an Ethereum client, transaction pool,
-/// and configuration, this function creates a transaction payload. Returns
-/// a result indicating success with the payload or an error in case of failure.
-#[inline]
-pub fn default_ethereum_payload<EvmConfig, Pool, Client, F>(
-    evm_config: EvmConfig,
-    builder_config: EthereumBuilderConfig,
-    args: BuildArguments<Pool, Client, EthPayloadBuilderAttributes, EthBuiltPayload>,
-    evm_env: EvmEnv<EvmConfig::Spec>,
-    block_rewards_contract: Address,
-    best_txs: F,
-) -> Result<BuildOutcome<EthBuiltPayload>, PayloadBuilderError>
-where
-    EvmConfig: ConfigureEvm<Header = Header, Transaction = TransactionSigned>,
-    Client: StateProviderFactory + ChainSpecProvider<ChainSpec = GnosisChainSpec>,
-    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
-    F: FnOnce(BestTransactionsAttributes) -> BestTransactionsIter<Pool>,
-{
-    let BuildArguments {
-        client,
-        pool,
-        mut cached_reads,
-        config,
-        cancel,
-        best_payload,
-    } = args;
-    let chain_spec = client.chain_spec();
-    let state_provider = client.state_by_block_hash(config.parent_header.hash())?;
-    let state = StateProviderDatabase::new(state_provider);
-    let mut db = State::builder()
-        .with_database(cached_reads.as_db_mut(state))
-        .with_bundle_update()
-        .build();
-    let PayloadConfig {
-        parent_header,
-        attributes,
-    } = config;
-
-    debug!(target: "payload_builder", id=%attributes.id, parent_header = ?parent_header.hash(), parent_number = parent_header.number, "building new payload");
-    let mut cumulative_gas_used = 0;
-    let mut sum_blob_gas_used = 0;
-    let block_gas_limit: u64 = evm_env.block_env.gas_limit.to::<u64>();
-    let base_fee = evm_env.block_env.basefee.to::<u64>();
-
-    let mut executed_txs = Vec::new();
-
-    let mut best_txs = best_txs(BestTransactionsAttributes::new(
-        base_fee,
-        evm_env
-            .block_env
-            .get_blob_gasprice()
-            .map(|gasprice| gasprice as u64),
-    ));
-    let mut total_fees = U256::ZERO;
-
-    let block_number = evm_env.block_env.number.to::<u64>();
-    let beneficiary = evm_env.block_env.coinbase;
-
-    let mut system_caller = SystemCaller::new(evm_config.clone(), chain_spec.clone());
-
-    let mut evm = evm_config.evm_with_env(&mut db, evm_env);
-
-    system_caller
-        .apply_pre_execution_changes(&parent_header, &mut evm)
-        .map_err(|err| {
-            warn!(target: "payload_builder",
-                parent_hash=%parent_header.hash(),
-                %err,
-                "failed to apply pre-execution changes for payload"
-            );
-            PayloadBuilderError::Internal(err.into())
-        })?;
-
-    let mut receipts = Vec::new();
-    while let Some(pool_tx) = best_txs.next() {
-        // ensure we still have capacity for this transaction
-        if cumulative_gas_used + pool_tx.gas_limit() > block_gas_limit {
-            // we can't fit this transaction into the block, so we need to mark it as invalid
-            // which also removes all dependent transaction from the iterator before we can
-            // continue
-            best_txs.mark_invalid(
-                &pool_tx,
-                InvalidPoolTransactionError::ExceedsGasLimit(pool_tx.gas_limit(), block_gas_limit),
-            );
-            continue;
-        }
-
-        // check if the job was cancelled, if so we can exit early
-        if cancel.is_cancelled() {
-            return Ok(BuildOutcome::Cancelled);
-        }
-
-        // convert tx to a signed transaction
-        let tx = pool_tx.to_consensus();
-
-        // There's only limited amount of blob space available per block, so we need to check if
-        // the EIP-4844 can still fit in the block
-        if let Some(blob_tx) = tx.as_eip4844() {
-            let tx_blob_gas = blob_tx.blob_gas();
-            if sum_blob_gas_used + tx_blob_gas > MAX_DATA_GAS_PER_BLOCK {
-                // we can't fit this _blob_ transaction into the block, so we mark it as
-                // invalid, which removes its dependent transactions from
-                // the iterator. This is similar to the gas limit condition
-                // for regular transactions above.
-                trace!(target: "payload_builder", tx=?tx.hash(), ?sum_blob_gas_used, ?tx_blob_gas, "skipping blob transaction because it would exceed the max data gas per block");
-                best_txs.mark_invalid(
-                    &pool_tx,
-                    InvalidPoolTransactionError::ExceedsGasLimit(
-                        tx_blob_gas,
-                        MAX_DATA_GAS_PER_BLOCK,
-                    ),
-                );
-                continue;
-            }
-        }
-
-        // Configure the environment for the tx.
-        let tx_env = evm_config.tx_env(tx.tx(), tx.signer());
-
-        let ResultAndState { result, state } = match evm.transact(tx_env) {
-            Ok(res) => res,
-            Err(err) => {
-                match err {
-                    EVMError::Transaction(err) => {
-                        if matches!(err, InvalidTransaction::NonceTooLow { .. }) {
-                            // if the nonce is too low, we can skip this transaction
-                            trace!(target: "payload_builder", %err, ?tx, "skipping nonce too low transaction");
-                        } else {
-                            // if the transaction is invalid, we can skip it and all of its
-                            // descendants
-                            trace!(target: "payload_builder", %err, ?tx, "skipping invalid transaction and its descendants");
-                            best_txs.mark_invalid(
-                                &pool_tx,
-                                InvalidPoolTransactionError::Consensus(
-                                    InvalidTransactionError::TxTypeNotSupported,
-                                ),
-                            );
-                        }
-
-                        continue;
-                    }
-                    err => {
-                        // this is an error that we should treat as fatal for this attempt
-                        return Err(PayloadBuilderError::EvmExecutionError(err));
-                    }
-                }
-            }
-        };
-
-        // commit changes
-        evm.db_mut().commit(state);
-
-        // add to the total blob gas used if the transaction successfully executed
-        if let Some(blob_tx) = tx.as_eip4844() {
-            let tx_blob_gas = blob_tx.blob_gas();
-            sum_blob_gas_used += tx_blob_gas;
-
-            // if we've reached the max data gas per block, we can skip blob txs entirely
-            if sum_blob_gas_used == MAX_DATA_GAS_PER_BLOCK {
-                best_txs.skip_blobs();
-            }
-        }
-
-        let gas_used = result.gas_used();
-
-        // add gas used by the transaction to cumulative gas used, before creating the receipt
-        cumulative_gas_used += gas_used;
-
-        // Push transaction changeset and calculate header bloom filter for receipt.
-        #[allow(clippy::needless_update)] // side-effect of optimism fields
-        receipts.push(Receipt {
-            tx_type: tx.tx_type(),
-            success: result.is_success(),
-            cumulative_gas_used,
-            logs: result.into_logs().into_iter().map(Into::into).collect(),
-            ..Default::default()
-        });
-
-        // update add to total fees
-        let miner_fee = tx
-            .effective_tip_per_gas(base_fee)
-            .expect("fee is always valid; execution succeeded");
-        total_fees += U256::from(miner_fee) * U256::from(gas_used);
-
-        // append transaction to the block body
-        executed_txs.push(tx.into_tx());
-    }
-
-    // check if we have a better block
-    if !is_better_payload(best_payload.as_ref(), total_fees) {
-        // Release db
-        drop(evm);
-
-        // can skip building the block
-        return Ok(BuildOutcome::Aborted {
-            fees: total_fees,
-            cached_reads,
-        });
-    }
-
-    // let mut evm = evm_config.evm_with_env(&mut db, env);
-
-    // < GNOSIS SPECIFIC
-    let (balance_increments, _requests) = apply_post_block_system_calls(
-        &chain_spec,
-        // &evm_config,
-        block_rewards_contract,
-        attributes.timestamp,
-        Some(&attributes.withdrawals),
-        attributes.suggested_fee_recipient,
-        &mut evm,
-    )
-    .map_err(|err| PayloadBuilderError::Internal(err.into()))?;
-    // GNOSIS SPECIFIC >
-
-    evm.db_mut()
-        .increment_balances(balance_increments)
-        .map_err(|err| {
-            warn!(target: "payload_builder",
-                parent_hash=%parent_header.hash(),
-                %err,
-                "failed to increment balances for payload"
-            );
-            PayloadBuilderError::Internal(err.into())
-        })?;
-
-    // calculate the requests and the requests root
-    let requests = if chain_spec.is_prague_active_at_timestamp(attributes.timestamp) {
-        let deposit_requests = parse_deposits_from_receipts(&chain_spec, receipts.iter())
-            .map_err(|err| PayloadBuilderError::Internal(RethError::Execution(err.into())))?;
-
-        let mut requests = Requests::default();
-
-        if !deposit_requests.is_empty() {
-            requests.push_request_with_type(eip6110::DEPOSIT_REQUEST_TYPE, deposit_requests);
-        }
-
-        requests.extend(
-            system_caller
-                .apply_post_execution_changes(&mut evm)
-                .map_err(|err| PayloadBuilderError::Internal(err.into()))?,
-        );
-
-        Some(requests)
-    } else {
-        None
-    };
-
-    // Release db
-    drop(evm);
-
-    let withdrawals_root = Some(calculate_withdrawals_root(&attributes.withdrawals));
-
-    // merge all transitions into bundle state, this would apply the withdrawal balance changes
-    // and 4788 contract call
-    db.merge_transitions(BundleRetention::Reverts);
-
-    let requests_hash = requests.as_ref().map(|requests| requests.requests_hash());
-    let execution_outcome = ExecutionOutcome::new(
-        db.take_bundle(),
-        vec![receipts].into(),
-        block_number,
-        vec![requests.clone().unwrap_or_default()],
-    );
-    let receipts_root = execution_outcome
-        .ethereum_receipts_root(block_number)
-        .expect("Number is in range");
-    let logs_bloom = execution_outcome
-        .block_logs_bloom(block_number)
-        .expect("Number is in range");
-
-    // calculate the state root
-    let hashed_state = db.database.db.hashed_post_state(execution_outcome.state());
-    let (state_root, _) = {
-        db.database
-            .inner()
-            .state_root_with_updates(hashed_state)
-            .inspect_err(|err| {
-                warn!(target: "payload_builder",
-                    parent_hash=%parent_header.hash(),
-                    %err,
-                    "failed to calculate state root for payload"
-                );
-            })?
-    };
-
-    // create the block header
-    let transactions_root = proofs::calculate_transaction_root(&executed_txs);
-
-    // initialize empty blob sidecars at first. If cancun is active then this will
-    let mut blob_sidecars = Vec::new();
-    let mut excess_blob_gas = None;
-    let mut blob_gas_used = None;
-
-    // only determine cancun fields when active
-    if chain_spec.is_cancun_active_at_timestamp(attributes.timestamp) {
-        // grab the blob sidecars from the executed txs
-        blob_sidecars = pool
-            .get_all_blobs_exact(
-                executed_txs
-                    .iter()
-                    .filter(|tx| tx.is_eip4844())
-                    .map(|tx| *tx.tx_hash())
-                    .collect(),
-            )
-            .map_err(PayloadBuilderError::other)?;
-
-        excess_blob_gas = if chain_spec.is_cancun_active_at_timestamp(parent_header.timestamp) {
-            let blob_params = if chain_spec.is_prague_active_at_timestamp(attributes.timestamp) {
-                PRAGUE_BLOB_PARAMS
-            } else {
-                // cancun
-                CANCUN_BLOB_PARAMS
-            };
-            parent_header.next_block_excess_blob_gas(blob_params)
-        } else {
-            // for the first post-fork block, both parent.blob_gas_used and
-            // parent.excess_blob_gas are evaluated as 0
-            Some(alloy_eips::eip4844::calc_excess_blob_gas(0, 0))
-        };
-
-        blob_gas_used = Some(sum_blob_gas_used);
-    }
-
-    let header = Header {
-        parent_hash: parent_header.hash(),
-        ommers_hash: EMPTY_OMMER_ROOT_HASH,
-        beneficiary,
-        state_root,
-        transactions_root,
-        receipts_root,
-        withdrawals_root,
-        logs_bloom,
-        timestamp: attributes.timestamp,
-        mix_hash: attributes.prev_randao,
-        nonce: BEACON_NONCE.into(),
-        base_fee_per_gas: Some(base_fee),
-        number: parent_header.number + 1,
-        gas_limit: block_gas_limit,
-        difficulty: U256::ZERO,
-        gas_used: cumulative_gas_used,
-        extra_data: builder_config.extra_data,
-        parent_beacon_block_root: attributes.parent_beacon_block_root,
-        blob_gas_used: blob_gas_used.map(Into::into),
-        excess_blob_gas: excess_blob_gas.map(Into::into),
-        requests_hash,
-    };
-
-    let withdrawals = chain_spec
-        .is_shanghai_active_at_timestamp(attributes.timestamp)
-        .then(|| attributes.withdrawals.clone());
-
-    // seal the block
-    let block = Block {
-        header,
-        body: BlockBody {
-            transactions: executed_txs,
-            ommers: vec![],
-            withdrawals,
-        },
-    };
-
-    let sealed_block = Arc::new(block.seal_slow());
-    debug!(target: "payload_builder", id=%attributes.id, sealed_block_header = ?sealed_block.sealed_header(), "sealed built block");
-
-    let mut payload = EthBuiltPayload::new(attributes.id, sealed_block, total_fees, requests);
-
-    // extend the payload with the blob sidecars from the executed txs
-    payload.extend_sidecars(blob_sidecars.into_iter().map(Arc::unwrap_or_clone));
-
-    Ok(BuildOutcome::Better {
-        payload,
-        cached_reads,
-    })
 }


### PR DESCRIPTION
Upgraded the upstream reth version from [4eb65250a7430bf8699e1128f472b9cf842a54ae](https://github.com/paradigmxyz/reth/tree/4eb65250a7430bf8699e1128f472b9cf842a54ae) to [2933ec72987df396d1d3411323dc2260b522aab2](https://github.com/paradigmxyz/reth/tree/2933ec72987df396d1d3411323dc2260b522aab2).

This was necessary because in 4eb652, reth used the chainspec-specified blob params in some places, while the default mainnet params in others. This upgrade makes it consistent.

The updates are 1:1 with reth except:
* Refactoring payload_builder to extract the payload-specific logic to its own file. This is consistent with what reth does for ethereum ([payload](https://github.com/paradigmxyz/reth/blob/62a8e62c3dace6eef86b04b3086418f483e8ebbb/crates/ethereum/payload/src/lib.rs#L59-L70) vs [payload builder in node](https://github.com/paradigmxyz/reth/blob/1f1eabc42821086e40b981f64d8dc87b70cd9cad/crates/ethereum/node/src/payload.rs#L18-L20). This logic was already present in payload_builder [here](https://github.com/gnosischain/reth_gnosis/pull/51/files#diff-ad8cea6a920cb54687c777ed47f9503c071a5d98d1103871b8495786ab568e33L141-L178), but with the recent change in trait bounds, it needed to be separated to different files.
* `GnosisEvmConfig::new` parses the `eip1559collector` from the chain_spec instead of taking it as an input param
* In CI, `cache@v2` was changed to `cache@v3` because [CI test runs were failing](https://github.com/gnosischain/reth_gnosis/actions/runs/13269262957/job/37044541450) due to v2 being deprecated.

All other changes reflect upstream changes.