### PR TITLE
Fee collection after deducting from source account

### DIFF
--- a/src/evm_config.rs
+++ b/src/evm_config.rs
@@ -78,7 +78,6 @@ impl GnosisEvmConfig {
                 GnosisEvmFactory {
                     fee_collector_address,
                 },
-                fee_collector_address,
                 block_rewards_address,
             ),
             chain_spec,


### PR DESCRIPTION
Reth_gnosis used to credit the blob gas cost to the `fee_collector` using the evm's `incrememnt_balances`, which takes place at the end of the block. This resulted in the fee collection not getting included in traces (for eg. `trace_replayBlockTransactions`'s stateDiff or vmTraces).

Moving EIP-4844-pectra fee collection into the evm handler ensures it is captured by traces and happens along with tx execution. Making it part of the `deduct_caller` makes logical sense as we are 'collecting' it as soon as deducting it from source account (caller).

The earlier version of the code produced the CORRECT block state roots for both successful and failed blob transactions. This change ensures consistency with other clients, corrects the RPC's `trace_` namespace  and makes the blob fee collection follow logical order.