### PR TITLE
Script stability

### DIFF
--- a/scripts/chainspecs/gnosis.json
+++ b/scripts/chainspecs/gnosis.json
@@ -15,7 +15,7 @@
         "terminalTotalDifficultyPassed": true,
         "shanghaiTime": 1690889660,
         "cancunTime": 1710181820,
-        "pragueTime": 9999999999,
+        "pragueTime": 1746021820,
         "minBlobGasPrice": 1000000000,
         "maxBlobGasPerBlock": 262144,
         "targetBlobGasPerBlock": 131072,

--- a/scripts/download-data-gnosis.sh
+++ b/scripts/download-data-gnosis.sh
@@ -54,6 +54,12 @@ SIZES=(
   1728488631
 )
 
+if ! command -v jq &> /dev/null; then
+    echo -e "\033[0;31mError: 'jq' is not installed.\033[0m"
+    echo -e "\033[0;33mPlease install jq and try again.\033[0m"
+    exit 1
+fi
+
 # Loop through chunks 00 to 06
 for i in {0..6}; do
   CHUNK_FILE="chunk_0$i"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 DOCKER=false
 


### PR DESCRIPTION
* Adds a check to ensure `jq` is installed before proceeding with state download
* Surfaces inner-script errors to `setup.sh`