### PR TITLE
chore: bump reth 1.3.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,11 +97,11 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.64"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963fc7ac17f25d92c237448632330eb87b39ba8aa0209d4b517069a05b57db62"
+checksum = "7734aecfc58a597dde036e4c5cace2ae43e2f8bf3d406b022a1ef34da178dd49"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "num_enum",
  "serde",
@@ -110,15 +110,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84efb7b8ddb9223346bfad9d8094e1a100c254037a3b5913243bfa8e04be266"
+checksum = "c2179ba839ac532f50279f5da2a6c5047f791f03f6f808b4dfab11327b97902f"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "alloy-serde",
- "alloy-trie",
+ "alloy-trie 0.8.1",
  "arbitrary",
  "auto_impl",
  "c-kzg",
@@ -134,15 +134,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fafded0c1ff8f0275c4a484239058e1c01c0c2589f8a16e03669ef7094a06f9b"
+checksum = "aec6f67bdc62aa277e0ec13c1b1fb396c8a62b65c8e9bd8c1d3583cc6d1a8dd3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "alloy-serde",
+ "arbitrary",
  "serde",
 ]
 
@@ -152,10 +153,27 @@ version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7078bef2bc353c1d1a97b44981d0186198be320038fbfbb0b37d1dd822a555d3"
 dependencies = [
- "alloy-json-abi",
- "alloy-primitives",
- "alloy-sol-type-parser",
- "alloy-sol-types",
+ "alloy-json-abi 0.8.23",
+ "alloy-primitives 0.8.23",
+ "alloy-sol-type-parser 0.8.23",
+ "alloy-sol-types 0.8.23",
+ "const-hex",
+ "itoa",
+ "serde",
+ "serde_json",
+ "winnow",
+]
+
+[[package]]
+name = "alloy-dyn-abi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f90b63261b7744642f6075ed17db6de118eecbe9516ea6c6ffd444b80180b75"
+dependencies = [
+ "alloy-json-abi 1.1.0",
+ "alloy-primitives 1.1.0",
+ "alloy-sol-type-parser 1.1.0",
+ "alloy-sol-types 1.1.0",
  "const-hex",
  "derive_more 2.0.1",
  "itoa",
@@ -166,11 +184,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip2124"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675264c957689f0fd75f5993a73123c2cc3b5c235a38f5b9037fe6c826bfb2c0"
+checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "arbitrary",
  "crc",
@@ -181,11 +199,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip2930"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
+checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "arbitrary",
  "rand 0.8.5",
@@ -194,11 +212,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b15b13d38b366d01e818fe8e710d4d702ef7499eacd44926a06171dd9585d0c"
+checksum = "804cefe429015b4244966c006d25bda5545fa9db5990e9c9079faf255052f50a"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "arbitrary",
  "k256",
@@ -210,14 +228,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4bffedaddc627520eabdcbfe27a2d2c2f716e15295e2ed1010df3feae67040"
+checksum = "609515c1955b33af3d78d26357540f68c5551a90ef58fd53def04f2aa074ec43"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "alloy-serde",
  "arbitrary",
@@ -227,24 +245,24 @@ dependencies = [
  "either",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "once_cell",
  "serde",
  "sha2 0.10.8",
 ]
 
 [[package]]
 name = "alloy-evm"
-version = "0.1.0-alpha.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68af08d4a6c5b66b45e80e9811b9fa3dccd3cc08465246107b98fcf87afbf020"
+checksum = "caabd28657614cecc14d77fde0a630c5c177bfe432ce4ad99db0ad41d9219856"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-hardforks",
- "alloy-primitives",
- "alloy-sol-types",
+ "alloy-primitives 1.1.0",
+ "alloy-sol-types 1.1.0",
  "auto_impl",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
+ "op-alloy-consensus",
  "op-revm",
  "revm",
  "thiserror 2.0.12",
@@ -252,26 +270,26 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b11774716152a5204aff0e86a8c841df499ea81464e2b1f82b3f72d6a2ef32"
+checksum = "6dfec8348d97bd624901c6a4b22bb4c24df8a3128fc3d5e42d24f7b79dfa8588"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-serde",
- "alloy-trie",
+ "alloy-trie 0.8.1",
  "serde",
 ]
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac52fcdca02c101b5e651af856702dd35b1af31cb00a87350f562ada636b5033"
+checksum = "c7d3b2243e2adfaea41da41982f91ecab8083fa51b240d0427955d709f65b1b4"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "auto_impl",
  "dyn-clone",
  "serde",
@@ -283,20 +301,32 @@ version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec80745c33797e8baf547a8cfeb850e60d837fe9b9e67b3f579c1fcd26f527e9"
 dependencies = [
- "alloy-primitives",
- "alloy-sol-type-parser",
+ "alloy-primitives 0.8.23",
+ "alloy-sol-type-parser 0.8.23",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-json-abi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0068ae277f5ee3153a95eaea8ff10e188ed8ccde9b7f9926305415a2c0ab2442"
+dependencies = [
+ "alloy-primitives 1.1.0",
+ "alloy-sol-type-parser 1.1.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6929e607b0a56803c69c68adc6e8aae1644c94e37ea458aa2d0713fc77490e70"
+checksum = "3994ab6ff6bdeb5aebe65381a8f6a47534789817570111555e8ac413e242ce06"
 dependencies = [
- "alloy-primitives",
- "alloy-sol-types",
+ "alloy-primitives 1.1.0",
+ "alloy-sol-types 1.1.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -305,21 +335,21 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b14524c3605ed5ee173b966333089474415416a8cfd80ceb003c18fd6d1736"
+checksum = "0be3aa020a6d3aa7601185b4c1a7d6f3a5228cb5424352db63064b29a455c891"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-network-primitives",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "alloy-signer",
- "alloy-sol-types",
+ "alloy-sol-types 1.1.0",
  "async-trait",
  "auto_impl",
  "derive_more 2.0.1",
@@ -331,13 +361,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c06932646544ea341f0fda48d2c0fe4fda75bc132379cb84019cdfb6ddcb0fb"
+checksum = "498f2ee2eef38a6db0fc810c7bf7daebdf5f2fa8d04adb8bd53e54e91ddbdea3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-serde",
  "serde",
 ]
@@ -349,14 +379,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eacedba97e65cdc7ab592f2b22ef5d3ab8d60b2056bc3a6e6363577e8270ec6f"
 dependencies = [
  "alloy-rlp",
- "arbitrary",
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_arbitrary",
  "derive_more 2.0.1",
  "foldhash",
- "getrandom 0.2.15",
  "hashbrown 0.15.2",
  "indexmap 2.8.0",
  "itoa",
@@ -364,7 +391,6 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "proptest-derive",
  "rand 0.8.5",
  "ruint",
  "rustc-hash 2.1.1",
@@ -374,10 +400,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-provider"
-version = "0.12.5"
+name = "alloy-primitives"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1ec2eabd9b3acc46e59247c35f75545960372431c68f7fdbfcfb970a486c30"
+checksum = "6a12fe11d0b8118e551c29e1a67ccb6d01cc07ef08086df30f07487146de6fa1"
+dependencies = [
+ "alloy-rlp",
+ "arbitrary",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_arbitrary",
+ "derive_more 2.0.1",
+ "foldhash",
+ "getrandom 0.3.1",
+ "hashbrown 0.15.2",
+ "indexmap 2.8.0",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "proptest-derive",
+ "rand 0.9.0",
+ "ruint",
+ "rustc-hash 2.1.1",
+ "serde",
+ "sha3",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-provider"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6ba76d476f475668925f858cc4db51781f12abdaa4e0274eb57a09f574e869"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -385,11 +442,12 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
- "alloy-sol-types",
+ "alloy-signer",
+ "alloy-sol-types 1.1.0",
  "alloy-transport",
  "alloy-transport-http",
  "alloy-transport-ipc",
@@ -398,6 +456,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "dashmap 6.1.0",
+ "either",
  "futures",
  "futures-utils-wasm",
  "lru 0.13.0",
@@ -415,21 +474,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1cf194abddb88b034d22ab41449ed8532e5113e58699cd055bf21d98a0991ab"
+checksum = "04135d2fd7fa1fba3afe9f79ec2967259dbc0948e02fa0cd0e33a4a812e2cb0a"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-transport",
  "bimap",
  "futures",
+ "parking_lot",
  "serde",
  "serde_json",
  "tokio",
  "tokio-stream",
  "tower 0.5.2",
  "tracing",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -456,17 +517,18 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6213829d8eabc239c2f9572452a5993ebdf78b04c020abc450ae48c54261d4ce"
+checksum = "1d6a6985b48a536b47aa0aece56e6a0f49240ce5d33a7f0c94f1b312eda79aa1"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
  "alloy-transport-ipc",
  "alloy-transport-ws",
+ "async-stream",
  "futures",
  "pin-project",
  "reqwest",
@@ -476,17 +538,18 @@ dependencies = [
  "tokio-stream",
  "tower 0.5.2",
  "tracing",
+ "tracing-futures",
  "url",
  "wasmtimer",
 ]
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a153db94cf231b03238fe4da48f59dc6f36e01b5e4d5a2e30de33b95395380fa"
+checksum = "3bf27873220877cb15125eb6eec2f86c6e9b41473aca85844bd3d9d755bfc0a0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-serde",
@@ -495,23 +558,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5275d2e24dbdd82032c3b305db359fb2681069cc75add7feb66863ce50b5cb5"
+checksum = "564fbba310fbfdadf16512c973315d0fa8eaf8fd2c442f1265bfc24e51f41ddf"
 dependencies = [
  "alloy-genesis",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5462937f088889c337c236c2509226e87a26301d2b01f9fafee246bd84cb0407"
+checksum = "8c349f7339476f13e23308111dfeb67d136c11e7b2a6b1d162f6a124ad4ffb9b"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -519,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd4ceea38ea27eeb26f021df34ed5b7b793704ad7a2a009f16137a19461e7ca"
+checksum = "d1a40595b927dfb07218459037837dbc8de8500a26024bb6ff0548dd2ccc13e0"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -530,12 +593,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c14f3c5747750f7373ec9f633230923ff149c2e31960513e31593bcfcf916be"
+checksum = "77c08a6f2593a8b6401e579996a887b22794543e0ff5976c5c21ddd361755dec"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-engine",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -548,23 +611,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fa8f6e27d47b4c56c627cb03dc91624c26bd814f6609bb1d1a836148b76fc9b"
+checksum = "05525519bd7f37f98875354f0b3693d3ad3c7a7f067e3b8946777920be15cb5b"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a1a0710dbfbab2b33200ef45c650963d63edf6a81b2c7399ede762b3586dfd"
+checksum = "4235d79af20fe5583ca26096258fe9307571a345745c433cfd8c91b41aa2611e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "alloy-serde",
  "derive_more 2.0.1",
@@ -579,18 +642,18 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e18d94b1036302720b987564560e4a5b85035a17553c53a50afa2bd8762b487"
+checksum = "f2a9f64e0f69cfb6029e2a044519a1bdd44ce9fc334d5315a7b9837f7a6748e5"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
  "alloy-eips",
  "alloy-network-primitives",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "alloy-serde",
- "alloy-sol-types",
+ "alloy-sol-types 1.1.0",
  "arbitrary",
  "itertools 0.14.0",
  "jsonrpsee-types",
@@ -601,12 +664,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec941a4b3eedf15daef2b7aeb7848dfc6e677f58b2a21eab0ac1efef1ffac62"
+checksum = "96b38fc4f5a198a14b1411c27c530c95fd05800613175a4c98ae61475c41b7c5"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -615,11 +678,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef4bba67ec601730ceb23e542980d73ae9f718819604dfdd8289b13a506e762"
+checksum = "2bccbe4594eaa2d69d21fa0b558c44e36202e599eb209da70b405415cb37a354"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -629,11 +692,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8edc8512f919feb79dd30864ef7574d2877e71b73e30b5de4925ba9bc6bd4f96"
+checksum = "56b8de4afea88d9ca1504b9dee40ffae69a2364aed82ab6e88e4348b41f57f6b"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -641,11 +704,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9824e1bf92cd7848ca6fabb01c9aca15c9c5fb0ab96da5514ef0543f021c69f6"
+checksum = "d4dba6ff08916bc0a9cbba121ce21f67c0b554c39cf174bc7b9df6c651bd3c3b"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "arbitrary",
  "serde",
  "serde_json",
@@ -653,11 +716,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81755ed6a6a33061302ac95e9bb7b40ebf7078e4568397168024242bc31a3e58"
+checksum = "0c580da7f00f3999e44e327223044d6732358627f93043e22d92c583f6583556"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "async-trait",
  "auto_impl",
  "either",
@@ -668,13 +731,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa857621a5c95c13e640e18bb9c4720f4338a666d6276f55446477a6bc3912ff"
+checksum = "a00f0f07862bd8f6bc66c953660693c5903062c2c9d308485b2a6eee411089e7"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-signer",
  "async-trait",
  "k256",
@@ -688,8 +751,22 @@ version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3637022e781bc73a9e300689cd91105a0e6be00391dd4e2110a71cc7e9f20a94"
 dependencies = [
- "alloy-sol-macro-expander",
- "alloy-sol-macro-input",
+ "alloy-sol-macro-expander 0.8.23",
+ "alloy-sol-macro-input 0.8.23",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d3ef8e0d622453d969ba3cded54cf6800efdc85cb929fe22c5bdf8335666757"
+dependencies = [
+ "alloy-sol-macro-expander 1.1.0",
+ "alloy-sol-macro-input 1.1.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -702,7 +779,7 @@ version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9bd22d0bba90e40f40c625c33d39afb7d62b22192476a2ce1dcf8409dce880"
 dependencies = [
- "alloy-sol-macro-input",
+ "alloy-sol-macro-input 0.8.23",
  "const-hex",
  "heck",
  "indexmap 2.8.0",
@@ -710,7 +787,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "syn-solidity",
+ "syn-solidity 0.8.23",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0e84bd0693c69a8fbe3ec0008465e029c6293494df7cb07580bf4a33eff52e1"
+dependencies = [
+ "alloy-sol-macro-input 1.1.0",
+ "const-hex",
+ "heck",
+ "indexmap 2.8.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "syn-solidity 1.1.0",
  "tiny-keccak",
 ]
 
@@ -727,7 +822,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "syn-solidity",
+ "syn-solidity 0.8.23",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3de663412dadf9b64f4f92f507f78deebcc92339d12cf15f88ded65d41c7935"
+dependencies = [
+ "const-hex",
+ "dunce",
+ "heck",
+ "macro-string",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "syn-solidity 1.1.0",
 ]
 
 [[package]]
@@ -741,27 +852,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-sol-type-parser"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "251273c5aa1abb590852f795c938730fa641832fc8fa77b5478ed1bf11b6097e"
+dependencies = [
+ "serde",
+ "winnow",
+]
+
+[[package]]
 name = "alloy-sol-types"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "767957235807b021126dca1598ac3ef477007eace07961607dc5f490550909c7"
 dependencies = [
- "alloy-json-abi",
- "alloy-primitives",
- "alloy-sol-macro",
+ "alloy-json-abi 0.8.23",
+ "alloy-primitives 0.8.23",
+ "alloy-sol-macro 0.8.23",
+ "const-hex",
+ "serde",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5460a975434ae594fe2b91586253c1beb404353b78f0a55bf124abcd79557b15"
+dependencies = [
+ "alloy-json-abi 1.1.0",
+ "alloy-primitives 1.1.0",
+ "alloy-sol-macro 1.1.0",
  "const-hex",
  "serde",
 ]
 
 [[package]]
 name = "alloy-transport"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c74598eb65cefa886be6ba624c14a6856d9d84339ec720520f3efcc03311716"
+checksum = "6e1f1a55f9ff9a48aa0b4a8c616803754620010fbb266edae2f4548f4304373b"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
+ "derive_more 2.0.1",
+ "futures",
  "futures-utils-wasm",
+ "parking_lot",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -774,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcd2f8ab2f053cd848ead5d625cb1b63716562951101588c1fa49300e3c6418"
+checksum = "171b3d8824b6697d6c8325373ec410d230b6c59ce552edfbfabe4e7b8a26aac3"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -789,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e61e2b5cbf16f7588e4420848b61824f6514944773732534f4129ba6a251e059"
+checksum = "f8a71043836f2144e1fe30f874eb2e9d71d2632d530e35b09fadbf787232f3f4"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -809,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ddcf4b98b3448eb998e057dc5a27345997863d6544ee7f0f79957616768dd3"
+checksum = "fdde5b241745076bcbf2fcad818f2c42203bd2c5f4b50ea43b628ccbd2147ad6"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -831,12 +968,27 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d95a94854e420f07e962f7807485856cde359ab99ab6413883e15235ad996e8b"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.23",
+ "alloy-rlp",
+ "arrayvec",
+ "derive_more 1.0.0",
+ "nybbles",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
+dependencies = [
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "arbitrary",
  "arrayvec",
  "derive_arbitrary",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "nybbles",
  "proptest",
  "proptest-derive",
@@ -940,6 +1092,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-bls12-381"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-bn254"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-r1cs-std",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-poly",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.2",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +1175,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +1212,16 @@ checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1023,6 +1250,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "ark-r1cs-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-relations",
+ "ark-std 0.5.0",
+ "educe",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "tracing",
+]
+
+[[package]]
+name = "ark-relations"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
+dependencies = [
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
+ "tracing",
+ "tracing-subscriber 0.2.25",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1328,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "ark-std"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,6 +1366,16 @@ name = "ark-std"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
@@ -1098,17 +1416,6 @@ dependencies = [
  "tokio",
  "zstd",
  "zstd-safe",
-]
-
-[[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -1631,10 +1938,11 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "1.0.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0307f72feab3300336fb803a57134159f6e20139af1357f36c54cb90d8e8928"
+checksum = "4e7e3c397401eb76228c89561cf22f85f41c95aa799ee9d860de3ea1cbc728fc"
 dependencies = [
+ "arbitrary",
  "blst",
  "cc",
  "glob",
@@ -1925,15 +2233,6 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
-
-[[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "convert_case"
@@ -2365,11 +2664,9 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
- "convert_case 0.6.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "unicode-xid",
 ]
 
 [[package]]
@@ -2378,7 +2675,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
- "convert_case 0.7.1",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -2557,6 +2854,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2633,6 +2942,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "enumn"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,11 +3010,11 @@ dependencies = [
 
 [[package]]
 name = "ethereum_serde_utils"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70cbccfccf81d67bff0ab36e591fa536c8a935b078a7b0e58c1d00d418332fc9"
+checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "hex",
  "serde",
  "serde_derive",
@@ -2694,11 +3023,11 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz"
-version = "0.8.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86da3096d1304f5f28476ce383005385459afeaf0eea08592b65ddbc9b258d16"
+checksum = "9ca8ba45b63c389c6e115b095ca16381534fdcc03cf58176a3f8554db2dbe19b"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "ethereum_serde_utils",
  "itertools 0.13.0",
  "serde",
@@ -2709,9 +3038,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz_derive"
-version = "0.8.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d832a5c38eba0e7ad92592f7a22d693954637fbb332b4f669590d66a5c3183e5"
+checksum = "0dd55d08012b4e0dfcc92b8d6081234df65f2986ad34cc76eeed69c5e2ce7506"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3230,11 +3559,10 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.25.0-alpha.5"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d00147af6310f4392a31680db52a3ed45a2e0f68eb18e8c3fe5537ecc96d9e2"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
- "async-recursion",
  "async-trait",
  "cfg-if",
  "data-encoding",
@@ -3246,6 +3574,7 @@ dependencies = [
  "ipnet",
  "once_cell",
  "rand 0.9.0",
+ "ring",
  "serde",
  "thiserror 2.0.12",
  "tinyvec",
@@ -3256,9 +3585,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.25.0-alpha.5"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5762f69ebdbd4ddb2e975cd24690bf21fe6b2604039189c26acddbc427f12887"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3433,7 +3762,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -3877,16 +4206,18 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
-version = "0.19.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
+ "cfg-if",
  "combine",
  "jni-sys",
  "log",
  "thiserror 1.0.69",
  "walkdir",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3916,9 +4247,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834af00800e962dee8f7bfc0f60601de215e73e78e5497d733a2919da837d3c8"
+checksum = "37b26c20e2178756451cfeb0661fb74c47dd5988cb7e3939de7e9241fd604d42"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -3934,9 +4265,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def0fd41e2f53118bd1620478d12305b2c75feef57ea1f93ef70568c98081b7e"
+checksum = "bacb85abf4117092455e1573625e21b8f8ef4dec8aff13361140b2dc266cdff2"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3959,9 +4290,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76637f6294b04e747d68e69336ef839a3493ca62b35bf488ead525f7da75c5bb"
+checksum = "456196007ca3a14db478346f58c7238028d55ee15c1df15115596e411ff27925"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3986,9 +4317,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c24e981ad17798bbca852b0738bfb7b94816ed687bd0d5da60bfa35fa0fdc3"
+checksum = "c872b6c9961a4ccc543e321bb5b89f6b2d2c7fe8b61906918273a3333c95400c"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4011,9 +4342,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcae0c6c159e11541080f1f829873d8f374f81eda0abc67695a13fc8dc1a580"
+checksum = "5e65763c942dfc9358146571911b0cd1c361c2d63e2d2305622d40d36376ca80"
 dependencies = [
  "heck",
  "proc-macro-crate",
@@ -4024,9 +4355,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b7a3df90a1a60c3ed68e7ca63916b53e9afa928e33531e87f61a9c8e9ae87b"
+checksum = "55e363146da18e50ad2b51a0a7925fc423137a0b1371af8235b1c231a0647328"
 dependencies = [
  "futures-util",
  "http",
@@ -4051,9 +4382,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddb81adb1a5ae9182df379e374a79e24e992334e7346af4d065ae5b2acb8d4c6"
+checksum = "08a8e70baf945b6b5752fc8eb38c918a48f1234daf11355e07106d963f860089"
 dependencies = [
  "http",
  "serde",
@@ -4063,9 +4394,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e41af42ca39657313748174d02766e5287d3a57356f16756dbd8065b933977"
+checksum = "e6558a9586cad43019dafd0b6311d0938f46efc116b34b28c74778bc11a2edf6"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -4074,9 +4405,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4f3642a292f5b76d8a16af5c88c16a0860f2ccc778104e5c848b28183d9538"
+checksum = "01b3323d890aa384f12148e8d2a1fd18eb66e9e7e825f9de4fa53bcc19b93eef"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",
@@ -4159,9 +4490,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "libc"
@@ -4359,7 +4687,7 @@ dependencies = [
  "generator",
  "scoped-tls",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
@@ -4884,17 +5212,17 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.11.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5099f9c3a41a313dd5f7fe7657545d972781e53d70c62976858aba8dac9eef"
+checksum = "f6f400404e37862bb974fbc3ad2d8ca2a2df286b718e762446496d04267ee912"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "alloy-serde",
  "arbitrary",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "serde",
  "serde_with",
  "thiserror 2.0.12",
@@ -4902,15 +5230,16 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.11.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e829ee4a0f373132258ccdce71ed1984cdbf7df83ab928522997ee79943879c2"
+checksum = "e614936d3f113b8e3dd2724382bd8db6700bd48fcd1f4d62bef537f3be8f710e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
+ "alloy-rlp",
  "alloy-rpc-types-engine",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "ethereum_ssz",
  "op-alloy-consensus",
  "snap",
@@ -4919,9 +5248,9 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "1.0.0-alpha.4"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bace6de3cbeca7d98d49354b3812c6d72fc609c54e162ce9db0dae1c82d2eb57"
+checksum = "12f8646cb935063087579f44da58fe1dea329c280c3b35898d6fd01a928de91f"
 dependencies = [
  "auto_impl",
  "once_cell",
@@ -5512,6 +5841,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+ "serde",
  "zerocopy 0.8.23",
 ]
 
@@ -5551,6 +5881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.1",
+ "serde",
 ]
 
 [[package]]
@@ -5731,7 +6062,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -5763,12 +6094,12 @@ dependencies = [
 
 [[package]]
 name = "reth"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "alloy-rpc-types",
  "aquamarine",
@@ -5836,23 +6167,23 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "futures-core",
  "futures-util",
  "metrics",
+ "reth-chain-state",
  "reth-metrics",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives",
  "reth-primitives-traits",
- "reth-provider",
  "reth-revm",
+ "reth-storage-api",
  "reth-tasks",
  "tokio",
  "tracing",
@@ -5860,19 +6191,19 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-signer",
  "alloy-signer-local",
  "derive_more 2.0.1",
  "metrics",
  "parking_lot",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.9.0",
  "reth-chainspec",
  "reth-errors",
  "reth-ethereum-primitives",
@@ -5890,16 +6221,16 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
  "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
+ "alloy-primitives 1.1.0",
+ "alloy-trie 0.8.1",
  "auto_impl",
  "derive_more 2.0.1",
  "reth-ethereum-forks",
@@ -5910,8 +6241,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -5924,13 +6255,13 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "ahash",
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "backon",
  "clap",
@@ -5955,7 +6286,6 @@ dependencies = [
  "reth-downloaders",
  "reth-ecies",
  "reth-eth-wire",
- "reth-ethereum-cli",
  "reth-evm",
  "reth-exex",
  "reth-fs-util",
@@ -5985,8 +6315,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -5995,11 +6325,11 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "cfg-if",
  "eyre",
  "libc",
@@ -6013,29 +6343,30 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
+ "alloy-primitives 1.1.0",
+ "alloy-trie 0.8.1",
  "arbitrary",
  "bytes",
  "modular-bitfield",
  "op-alloy-consensus",
  "reth-codecs-derive",
+ "reth-zstd-compressors",
  "serde",
  "visibility",
 ]
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
- "convert_case 0.7.1",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -6043,8 +6374,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -6057,11 +6388,11 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
@@ -6070,8 +6401,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6082,12 +6413,12 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-provider",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -6105,10 +6436,10 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "derive_more 2.0.1",
  "eyre",
  "metrics",
@@ -6131,12 +6462,12 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "arbitrary",
  "bytes",
  "derive_more 2.0.1",
@@ -6159,12 +6490,12 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "boyer-moore-magiclen",
  "eyre",
  "reth-chainspec",
@@ -6188,11 +6519,11 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "arbitrary",
  "bytes",
  "modular-bitfield",
@@ -6203,10 +6534,10 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "discv5",
  "enr",
@@ -6229,10 +6560,10 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "derive_more 2.0.1",
  "discv5",
@@ -6240,7 +6571,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "metrics",
- "rand 0.8.5",
+ "rand 0.9.0",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-metrics",
@@ -6253,10 +6584,10 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "data-encoding",
  "enr",
  "hickory-resolver",
@@ -6277,12 +6608,12 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "futures",
  "futures-util",
@@ -6295,7 +6626,6 @@ dependencies = [
  "reth-metrics",
  "reth-network-p2p",
  "reth-network-peers",
- "reth-primitives",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
@@ -6308,11 +6638,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "aes",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "block-padding",
  "byteorder",
@@ -6339,11 +6669,11 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-engine",
  "eyre",
  "futures-util",
@@ -6368,20 +6698,20 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-engine",
  "auto_impl",
  "futures",
  "reth-chain-state",
  "reth-errors",
+ "reth-ethereum-primitives",
  "reth-execution-types",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives",
  "reth-primitives-traits",
  "reth-trie",
  "reth-trie-common",
@@ -6392,8 +6722,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "futures",
  "pin-project",
@@ -6401,11 +6731,11 @@ dependencies = [
  "reth-consensus",
  "reth-engine-primitives",
  "reth-engine-tree",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-network-p2p",
  "reth-node-types",
  "reth-payload-builder",
- "reth-primitives",
  "reth-provider",
  "reth-prune",
  "reth-stages-api",
@@ -6415,17 +6745,18 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "derive_more 2.0.1",
  "futures",
+ "itertools 0.14.0",
  "metrics",
  "mini-moka",
  "parking_lot",
@@ -6460,8 +6791,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -6475,10 +6806,9 @@ dependencies = [
  "reth-evm",
  "reth-fs-util",
  "reth-payload-primitives",
- "reth-primitives",
  "reth-primitives-traits",
- "reth-provider",
  "reth-revm",
+ "reth-storage-api",
  "serde",
  "serde_json",
  "tokio",
@@ -6488,23 +6818,22 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
- "reth-fs-util",
  "reth-storage-errors",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-chains",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "bytes",
  "derive_more 2.0.1",
@@ -6528,19 +6857,19 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-hardforks",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "bytes",
  "derive_more 2.0.1",
  "reth-chainspec",
  "reth-codecs-derive",
- "reth-ethereum-forks",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "serde",
@@ -6549,8 +6878,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "eyre",
  "reth-chainspec",
@@ -6559,12 +6888,12 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
@@ -6575,11 +6904,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
@@ -6592,13 +6921,12 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
- "alloy-primitives",
- "arbitrary",
+ "alloy-primitives 1.1.0",
  "auto_impl",
  "once_cell",
  "rustc-hash 2.1.1",
@@ -6606,12 +6934,12 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-engine",
  "reth-basic-payload-builder",
  "reth-chainspec",
@@ -6633,17 +6961,16 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
  "alloy-network",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde",
  "arbitrary",
  "derive_more 2.0.1",
  "modular-bitfield",
@@ -6654,12 +6981,13 @@ dependencies = [
  "revm-context",
  "secp256k1",
  "serde",
+ "serde_with",
 ]
 
 [[package]]
 name = "reth-etl"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -6668,13 +6996,13 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "auto_impl",
  "derive_more 2.0.1",
  "futures-util",
@@ -6690,18 +7018,17 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie-common",
  "revm",
- "revm-database",
 ]
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
@@ -6713,11 +7040,11 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-evm",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "nybbles",
  "reth-storage-errors",
@@ -6726,31 +7053,30 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "derive_more 2.0.1",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "reth-trie-common",
  "revm",
- "revm-database",
  "serde",
  "serde_with",
 ]
 
 [[package]]
 name = "reth-exex"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "eyre",
  "futures",
  "itertools 0.14.0",
@@ -6759,6 +7085,7 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-config",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-exex-types",
  "reth-fs-util",
@@ -6766,7 +7093,6 @@ dependencies = [
  "reth-node-api",
  "reth-node-core",
  "reth-payload-builder",
- "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune-types",
@@ -6783,14 +7109,13 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "reth-chain-state",
  "reth-execution-types",
- "reth-primitives",
  "reth-primitives-traits",
  "serde",
  "serde_with",
@@ -6798,8 +7123,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "serde",
  "serde_json",
@@ -6808,11 +7133,11 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "alloy-rpc-types-debug",
  "eyre",
@@ -6822,7 +7147,6 @@ dependencies = [
  "reth-chainspec",
  "reth-engine-primitives",
  "reth-evm",
- "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
@@ -6835,8 +7159,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6856,8 +7180,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "bitflags 2.9.0",
  "byteorder",
@@ -6873,8 +7197,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "bindgen",
  "cc",
@@ -6882,8 +7206,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "futures",
  "metrics",
@@ -6894,16 +7218,16 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -6916,12 +7240,12 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
@@ -6934,6 +7258,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.8.5",
+ "rand 0.9.0",
  "reth-chainspec",
  "reth-consensus",
  "reth-discv4",
@@ -6951,7 +7276,6 @@ dependencies = [
  "reth-network-p2p",
  "reth-network-peers",
  "reth-network-types",
- "reth-primitives",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
@@ -6971,10 +7295,10 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-admin",
  "auto_impl",
  "derive_more 2.0.1",
@@ -6994,12 +7318,12 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "auto_impl",
  "derive_more 2.0.1",
  "futures",
@@ -7017,10 +7341,10 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "enr",
  "secp256k1",
@@ -7032,8 +7356,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -7046,8 +7370,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7063,8 +7387,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -7087,12 +7411,12 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types",
  "alloy-rpc-types-engine",
  "aquamarine",
@@ -7127,7 +7451,6 @@ dependencies = [
  "reth-node-events",
  "reth-node-metrics",
  "reth-payload-builder",
- "reth-primitives",
  "reth-provider",
  "reth-prune",
  "reth-rpc",
@@ -7150,12 +7473,12 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-engine",
  "clap",
  "derive_more 2.0.1",
@@ -7163,7 +7486,7 @@ dependencies = [
  "eyre",
  "futures",
  "humantime",
- "rand 0.8.5",
+ "rand 0.9.0",
  "reth-chainspec",
  "reth-cli-util",
  "reth-config",
@@ -7177,7 +7500,6 @@ dependencies = [
  "reth-network",
  "reth-network-p2p",
  "reth-network-peers",
- "reth-primitives",
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-rpc-eth-types",
@@ -7201,9 +7523,10 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
+ "alloy-eips",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "eyre",
@@ -7236,12 +7559,12 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-engine",
  "derive_more 2.0.1",
  "futures",
@@ -7260,8 +7583,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "eyre",
  "http",
@@ -7281,8 +7604,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -7294,35 +7617,26 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
  "arbitrary",
  "bytes",
- "derive_more 2.0.1",
  "op-alloy-consensus",
- "op-revm",
- "rand 0.8.5",
  "reth-codecs",
  "reth-primitives-traits",
  "reth-zstd-compressors",
- "revm-context",
- "secp256k1",
  "serde",
  "serde_with",
 ]
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types",
@@ -7341,8 +7655,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -7353,18 +7667,18 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-engine",
  "auto_impl",
  "op-alloy-rpc-types-engine",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
- "reth-primitives",
+ "reth-primitives-traits",
  "serde",
  "thiserror 2.0.12",
  "tokio",
@@ -7372,8 +7686,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7382,11 +7696,10 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
- "arbitrary",
  "c-kzg",
  "once_cell",
  "reth-ethereum-forks",
@@ -7397,15 +7710,15 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
- "alloy-trie",
+ "alloy-trie 0.8.1",
  "arbitrary",
  "auto_impl",
  "byteorder",
@@ -7430,12 +7743,12 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-engine",
  "auto_impl",
  "dashmap 6.1.0",
@@ -7452,6 +7765,7 @@ dependencies = [
  "reth-db-api",
  "reth-errors",
  "reth-ethereum-engine-primitives",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
  "reth-fs-util",
@@ -7459,10 +7773,10 @@ dependencies = [
  "reth-network-p2p",
  "reth-nippy-jar",
  "reth-node-types",
- "reth-primitives",
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-stages-types",
+ "reth-static-file-types",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
@@ -7476,12 +7790,12 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "itertools 0.14.0",
  "metrics",
  "rayon",
@@ -7504,10 +7818,10 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "arbitrary",
  "derive_more 2.0.1",
  "modular-bitfield",
@@ -7518,11 +7832,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "futures",
  "reth-eth-wire",
@@ -7537,21 +7851,18 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "eyre",
  "futures",
  "parking_lot",
  "reth-chain-state",
- "reth-engine-primitives",
+ "reth-ethereum-primitives",
  "reth-evm",
- "reth-network",
- "reth-network-api",
  "reth-node-api",
- "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",
  "reth-ress-protocol",
@@ -7566,31 +7877,29 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
  "revm",
- "revm-database",
- "revm-inspector",
 ]
 
 [[package]]
 name = "reth-rpc"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
- "alloy-dyn-abi",
+ "alloy-dyn-abi 1.1.0",
  "alloy-eips",
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-rpc-types-admin",
@@ -7614,20 +7923,20 @@ dependencies = [
  "jsonwebtoken",
  "parking_lot",
  "pin-project",
- "rand 0.8.5",
+ "reth-chain-state",
  "reth-chainspec",
  "reth-consensus",
  "reth-engine-primitives",
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-evm",
+ "reth-execution-types",
  "reth-metrics",
  "reth-network-api",
  "reth-network-peers",
  "reth-network-types",
  "reth-node-api",
  "reth-primitives-traits",
- "reth-provider",
  "reth-revm",
  "reth-rpc-api",
  "reth-rpc-engine-api",
@@ -7635,6 +7944,7 @@ dependencies = [
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
  "reth-rpc-types-compat",
+ "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
  "revm",
@@ -7652,13 +7962,13 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
  "alloy-json-rpc",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-anvil",
@@ -7678,8 +7988,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -7715,11 +8025,11 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-engine",
  "async-trait",
  "jsonrpsee-core",
@@ -7734,6 +8044,7 @@ dependencies = [
  "reth-payload-primitives",
  "reth-primitives-traits",
  "reth-rpc-api",
+ "reth-rpc-server-types",
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
@@ -7745,15 +8056,15 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
- "alloy-dyn-abi",
+ "alloy-dyn-abi 1.1.0",
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-network",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-mev",
@@ -7788,28 +8099,28 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-eth",
- "alloy-sol-types",
+ "alloy-sol-types 1.1.0",
  "derive_more 2.0.1",
  "futures",
  "itertools 0.14.0",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics",
- "rand 0.8.5",
+ "rand 0.9.0",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
  "reth-metrics",
- "reth-primitives",
  "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-server-types",
@@ -7819,9 +8130,7 @@ dependencies = [
  "reth-transaction-pool",
  "reth-trie",
  "revm",
- "revm-database",
  "revm-inspectors",
- "revm-primitives",
  "schnellru",
  "serde",
  "thiserror 2.0.12",
@@ -7832,8 +8141,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -7846,11 +8155,11 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-engine",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -7862,11 +8171,11 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-types-compat"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-eth",
  "jsonrpsee-types",
  "reth-primitives-traits",
@@ -7875,12 +8184,12 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "bincode",
  "blake3",
  "futures-util",
@@ -7917,11 +8226,11 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "aquamarine",
  "auto_impl",
  "futures-util",
@@ -7944,10 +8253,10 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "arbitrary",
  "bytes",
  "modular-bitfield",
@@ -7958,14 +8267,13 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "parking_lot",
  "rayon",
  "reth-codecs",
- "reth-db",
  "reth-db-api",
  "reth-primitives-traits",
  "reth-provider",
@@ -7979,10 +8287,10 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "clap",
  "derive_more 2.0.1",
  "serde",
@@ -7991,12 +8299,12 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-engine",
  "auto_impl",
  "reth-chainspec",
@@ -8015,11 +8323,11 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "derive_more 2.0.1",
  "reth-primitives-traits",
@@ -8031,8 +8339,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -8049,8 +8357,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -8059,8 +8367,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "clap",
  "eyre",
@@ -8069,17 +8377,17 @@ dependencies = [
  "tracing-appender",
  "tracing-journald",
  "tracing-logfmt",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
@@ -8087,7 +8395,7 @@ dependencies = [
  "futures-util",
  "metrics",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.9.0",
  "reth-chain-state",
  "reth-chainspec",
  "reth-eth-wire-types",
@@ -8112,14 +8420,14 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
- "alloy-trie",
+ "alloy-trie 0.8.1",
  "auto_impl",
  "itertools 0.14.0",
  "metrics",
@@ -8137,15 +8445,15 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-serde",
- "alloy-trie",
+ "alloy-trie 0.8.1",
  "arbitrary",
  "bytes",
  "derive_more 2.0.1",
@@ -8163,42 +8471,37 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "derive_more 2.0.1",
- "metrics",
+ "alloy-primitives 1.1.0",
  "reth-db-api",
  "reth-execution-errors",
- "reth-metrics",
  "reth-primitives-traits",
  "reth-trie",
- "revm",
  "tracing",
- "triehash",
 ]
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "derive_more 2.0.1",
  "itertools 0.14.0",
  "metrics",
  "rayon",
+ "reth-db-api",
  "reth-execution-errors",
  "reth-metrics",
- "reth-primitives",
  "reth-provider",
  "reth-storage-errors",
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
+ "reth-trie-sparse",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -8206,23 +8509,25 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
+ "auto_impl",
+ "metrics",
  "reth-execution-errors",
+ "reth-metrics",
  "reth-primitives-traits",
  "reth-tracing",
  "reth-trie-common",
  "smallvec",
- "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a38c991c363d241894867a89324b8670be2f6a44#a38c991c363d241894867a89324b8670be2f6a44"
+version = "1.3.12"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.12#6f8e7258f4733279080e4bd8345ce50538a40d6e"
 dependencies = [
  "zstd",
 ]
@@ -8233,16 +8538,16 @@ version = "0.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-dyn-abi",
+ "alloy-dyn-abi 0.8.23",
  "alloy-eips",
  "alloy-evm",
  "alloy-genesis",
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "alloy-serde",
- "alloy-sol-macro",
- "alloy-sol-types",
- "alloy-trie",
+ "alloy-sol-macro 1.1.0",
+ "alloy-sol-types 1.1.0",
+ "alloy-trie 0.7.9",
  "anyhow",
  "clap",
  "derive_more 2.0.1",
@@ -8310,9 +8615,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "20.0.0-alpha.5"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4eafd506f0f00559874b343901fb441771b8d3722724d08dab6859d3339289f"
+checksum = "f5378e95ffe5c8377002dafeb6f7d370a55517cef7d6d6c16fc552253af3b123"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -8329,9 +8634,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "1.0.0-alpha.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad4e81fd3d5241ba201d2514a21835d8d06fa8bb7a2fb5b733a424a4776f0c4"
+checksum = "e63e138d520c5c5bc25ecc82506e9e4e6e85a811809fc5251c594378dccabfc6"
 dependencies = [
  "bitvec",
  "phf",
@@ -8341,9 +8646,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "1.0.0-alpha.4"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6aa6c3cd7ddd1aa68a0478f101fb5ebff83ee0566064b458cb3769725cde7fa"
+checksum = "9765628dfea4f3686aa8f2a72471c52801e6b38b601939ac16965f49bac66580"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -8357,9 +8662,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "1.0.0-alpha.4"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117c87d8d2fce323ea208a091a1b399fd0f74a208679952e0e88a8da061f016e"
+checksum = "82d74335aa1f14222cc4d3be1f62a029cc7dc03819cc8d080ff17b7e1d76375f"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -8372,12 +8677,11 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "1.0.0-alpha.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8e7b21693b74dbd9ee824a00225aad6a4ec9db903625304ae1ce0f4c0940c4"
+checksum = "2e5c80c5a2fd605f2119ee32a63fb3be941fb6a81ced8cdb3397abca28317224"
 dependencies = [
  "alloy-eips",
- "auto_impl",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -8387,9 +8691,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "1.0.0-alpha.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd54a44b415d510cffea16955888544ce54f987958578b40a52d15963462b259"
+checksum = "a0e4dfbc734b1ea67b5e8f8b3c7dc4283e2210d978cdaf6c7a45e97be5ea53b3"
 dependencies = [
  "auto_impl",
  "revm-primitives",
@@ -8399,9 +8703,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "1.0.0-alpha.5"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6048d06362493e8f0864d99ede5092ee2324db37e1e7d592fcb3c50e4af482"
+checksum = "8676379521c7bf179c31b685c5126ce7800eab5844122aef3231b97026d41a10"
 dependencies = [
  "auto_impl",
  "revm-bytecode",
@@ -8417,16 +8721,15 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "1.0.0-alpha.5"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b97116c773f9330b5d7f01796f57282f075389145d8e8932ac144d448356ad"
+checksum = "bfed4ecf999a3f6ae776ae2d160478c5dca986a8c2d02168e04066b1e34c789e"
 dependencies = [
  "auto_impl",
  "revm-context",
  "revm-database-interface",
  "revm-handler",
  "revm-interpreter",
- "revm-precompile",
  "revm-primitives",
  "revm-state",
  "serde",
@@ -8435,14 +8738,14 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.17.0-alpha.1"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1504e2851a11562fb350a9f408e5783351650aef11790aea0b0d0d9ab961c40"
+checksum = "859fdfb2ef545140a68f44d02cfe5524964f9478896cd0c793f5948959818640"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
- "alloy-sol-types",
+ "alloy-sol-types 1.1.0",
  "anstyle",
  "boa_engine",
  "boa_gc",
@@ -8455,9 +8758,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "16.0.0-alpha.5"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7273ce9185b2a63cbd6bc6cfb3bc2a611923f9fb0bd432bd565c4d8c0d5f606f"
+checksum = "feb20260342003cfb791536e678ef5bbea1bfd1f8178b170e8885ff821985473"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -8467,10 +8770,15 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "17.0.0-alpha.5"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e812019b128ea7f33efa36e88f68ed5d9400e835055fe31e2b7162bd9ddc97ef"
+checksum = "418e95eba68c9806c74f3e36cd5d2259170b61e90ac608b17ff8c435038ddace"
 dependencies = [
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
  "aurora-engine-modexp",
  "blst",
  "c-kzg",
@@ -8479,30 +8787,28 @@ dependencies = [
  "libsecp256k1",
  "once_cell",
  "p256",
- "revm-context-interface",
  "revm-primitives",
  "ripemd",
  "secp256k1",
  "sha2 0.10.8",
- "substrate-bn",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "16.0.0-alpha.3"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa626cac49fb6bfdbfed2a1cd232eb5f54d36281703092eaeec859111b1a220e"
+checksum = "1fc2283ff87358ec7501956c5dd8724a6c2be959c619c4861395ae5e0054575f"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "enumn",
  "serde",
 ]
 
 [[package]]
 name = "revm-state"
-version = "1.0.0-alpha.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3869d401da38fcf76021a6f5e4182fa027976f54763bc6ab2c477e440c6cd8f"
+checksum = "09dd121f6e66d75ab111fb51b4712f129511569bc3e41e6067ae760861418bd8"
 dependencies = [
  "bitflags 2.9.0",
  "revm-bytecode",
@@ -8617,9 +8923,9 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "ruint"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825df406ec217a8116bd7b06897c6cc8f65ffefc15d030ae2c9540acc9ed50b6"
+checksum = "78a46eb779843b2c4f21fac5773e25d6d5b7c8f0922876c91541790d2ca27eef"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -8635,6 +8941,7 @@ dependencies = [
  "primitive-types",
  "proptest",
  "rand 0.8.5",
+ "rand 0.9.0",
  "rlp",
  "ruint-macro",
  "serde",
@@ -8721,9 +9028,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.23"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "log",
  "once_cell",
@@ -8732,19 +9039,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "rustls-pki-types",
- "schannel",
- "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -8779,23 +9073,23 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.3.4"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afbb878bdfdf63a336a5e63561b1835e7a8c91524f51621db870169eac84b490"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
- "core-foundation 0.9.4",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
  "rustls",
- "rustls-native-certs 0.7.3",
+ "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 2.11.1",
+ "security-framework 3.2.0",
  "security-framework-sys",
- "webpki-roots",
- "winapi",
+ "webpki-root-certs 0.26.11",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8806,9 +9100,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "7149975849f1abb3832b246010ef62ccc80d3a76169517ada7188252b9cfb437"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -8932,7 +9226,6 @@ dependencies = [
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
- "num-bigint",
  "security-framework-sys",
 ]
 
@@ -9323,12 +9616,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9407,19 +9694,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "substrate-bn"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
-dependencies = [
- "byteorder",
- "crunchy",
- "lazy_static",
- "rand 0.8.5",
- "rustc-hex",
-]
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9452,6 +9726,18 @@ name = "syn-solidity"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d975606bae72d8aad5b07d9342465e123a2cccf53a5a735aedf81ca92a709ecb"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "syn-solidity"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0f0d4760f4c2a0823063b2c70e97aa2ad185f57be195172ccc0e23c4b787c4"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -9725,9 +10011,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
@@ -9949,7 +10235,7 @@ dependencies = [
  "crossbeam-channel",
  "thiserror 1.0.69",
  "time",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
@@ -9979,6 +10265,8 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
+ "futures",
+ "futures-task",
  "pin-project",
  "tracing",
 ]
@@ -9991,7 +10279,7 @@ checksum = "fc0b4143302cf1022dac868d521e36e8b27691f72c84b3311750d5188ebba657"
 dependencies = [
  "libc",
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
@@ -10014,7 +10302,7 @@ dependencies = [
  "time",
  "tracing",
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
@@ -10024,6 +10312,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
  "tracing-core",
 ]
 
@@ -10050,11 +10347,11 @@ dependencies = [
 
 [[package]]
 name = "tree_hash"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c58eb0f518840670270d90d97ffee702d8662d9c5494870c9e1e9e0fa00f668"
+checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.1.0",
  "ethereum_hashing",
  "ethereum_ssz",
  "smallvec",
@@ -10063,9 +10360,9 @@ dependencies = [
 
 [[package]]
 name = "tree_hash_derive"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699e7fb6b3fdfe0c809916f251cf5132d64966858601695c3736630a87e7166a"
+checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -10489,6 +10786,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.0",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a83f7e1a9f8712695c03eabe9ed3fbca0feff0152f33f12593e5a6303cb1a4"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10707,6 +11022,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -10730,6 +11054,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -10781,6 +11120,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -10799,6 +11144,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -10814,6 +11165,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10847,6 +11204,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -10862,6 +11225,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -10883,6 +11252,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -10898,6 +11273,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,60 +12,59 @@ name = "reth"
 path = "src/main.rs"
 
 [dependencies]
-reth = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-# reth-auto-seal-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-fs-util = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44", features = [
+reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-fs-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12", features = [
     "test-utils",
 ] }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-db-common = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-stages-api = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-stages-types = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "a38c991c363d241894867a89324b8670be2f6a44" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-db-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-stages-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-stages-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.12" }
 eyre = "0.6"
 clap = { version = "4.5.6", features = ["derive"] }
 derive_more = { version = "2", default-features = false, features = ["full"] }
 
 # revm
-revm = { version = "20.0.0-alpha.5", features = ["std"], default-features = false }
-revm-database = { version = "1.0.0-alpha.3", default-features = false }
-revm-state = { version = "1.0.0-alpha.3", default-features = false }
-revm-primitives = { version = "16.0.0-alpha.3", features = [
+revm = { version = "22.0.1", features = ["std"], default-features = false }
+revm-database = { version = "3.0.0", default-features = false }
+revm-state = { version = "3.0.0", default-features = false }
+revm-primitives = { version = "18.0.0", features = [
     "std",
 ], default-features = false }
-revm-inspectors = "0.17.0-alpha.1"
+revm-inspectors = "0.19"
 
 serde = { version = "1.0", features = ["derive"], default-features = false }
 serde_json = "1.0.94"
@@ -76,19 +75,19 @@ thiserror = { version = "2.0.0", default-features = false }
 thiserror-no-std = { version = "2.0.2", default-features = false }
 
 # eth
-alloy-chains = { version = "0.1.64", default-features = false }
+alloy-chains = { version = "0.2.0", default-features = false }
 alloy-dyn-abi = "0.8.20"
-alloy-evm = { version = "0.1.0-alpha.1", default-features = false }
-alloy-primitives = { version = "0.8.20", default-features = false }
+alloy-evm = { version = "0.5.0", default-features = false }
+alloy-primitives = { version = "1.1.0", default-features = false }
 alloy-rlp = { version = "0.3.10", default-features = false }
-alloy-sol-types = "0.8.20"
+alloy-sol-types = "1.1.0"
 alloy-trie = { version = "0.7.9", default-features = false }
 
-alloy-consensus = { version = "0.12.5", default-features = false }
-alloy-eips = { version = "0.12.5", default-features = false }
-alloy-genesis = { version = "0.12.5", default-features = false }
-alloy-sol-macro = "0.8.20"
-alloy-serde = { version = "0.12.5", default-features = false }
+alloy-consensus = { version = "0.14.0", default-features = false }
+alloy-eips = { version = "0.14.0", default-features = false }
+alloy-genesis = { version = "0.14.0", default-features = false }
+alloy-sol-macro = "1.1.0"
+alloy-serde = { version = "0.14.0", default-features = false }
 rayon = "1.7"
 
 tracing = "0.1.0"

--- a/src/blobs.rs
+++ b/src/blobs.rs
@@ -23,7 +23,7 @@ pub const GNOSIS_BLOB_SCHEDULE: HardforkBlobParams = HardforkBlobParams {
 };
 
 // helper function to create the evm's CfgEnv in get_cfg_env
-pub fn evm_env_blob_schedule() -> Vec<(SpecId, u8, u8)> {
+pub fn evm_env_blob_schedule() -> Vec<(SpecId, u64, u64)> {
     vec![(SpecId::CANCUN, 1, 2), (SpecId::PRAGUE, 1, 2)]
 }
 

--- a/src/evm/factory.rs
+++ b/src/evm/factory.rs
@@ -206,6 +206,8 @@ where
                 // clear the system address account from state transitions, else EIP-158/161 (impl in revm) removes it from state
                 res.state.remove(&alloy_eips::eip4788::SYSTEM_ADDRESS);
             }
+
+            res.state.remove(&self.block.beneficiary);
         }
 
         res

--- a/src/evm/factory.rs
+++ b/src/evm/factory.rs
@@ -104,6 +104,10 @@ where
         &self.block
     }
 
+    fn chain_id(&self) -> u64 {
+        self.cfg.chain_id
+    }
+
     fn transact_raw(
         &mut self,
         tx: Self::Tx,
@@ -182,6 +186,10 @@ where
         } = self.inner.0.data.ctx;
 
         (journaled_state.database, EvmEnv { block_env, cfg_env })
+    }
+
+    fn set_inspector_enabled(&mut self, enabled: bool) {
+        self.inspect = enabled;
     }
 }
 

--- a/src/evm/gnosis_evm.rs
+++ b/src/evm/gnosis_evm.rs
@@ -99,6 +99,7 @@ where
         Context = CTX,
         InterpreterTypes: InterpreterTypes<Output = InterpreterAction>,
     >,
+    P: PrecompileProvider<CTX>,
 {
     type Context = CTX;
     type Instructions = I;
@@ -194,6 +195,7 @@ where
         InterpreterTypes: InterpreterTypes<Output = InterpreterAction>,
     >,
     INSP: Inspector<CTX, I::InterpreterTypes>,
+    P: PrecompileProvider<CTX>,
 {
     type Inspector = INSP;
 

--- a/src/gnosis.rs
+++ b/src/gnosis.rs
@@ -67,7 +67,7 @@ where
         Err(e) => {
             return Err(BlockExecutionError::Internal(
                 InternalBlockExecutionError::Other(
-                    format!("withdrawal contract system call revert: {}", e).into(),
+                    format!("withdrawal contract system call revert: {e}").into(),
                 ),
             ))
         }
@@ -126,7 +126,7 @@ where
         Err(e) => {
             return Err(BlockExecutionError::from(
                 GnosisBlockExecutionError::CustomErrorMessage {
-                    message: format!("block rewards contract system call error: {}", e),
+                    message: format!("block rewards contract system call error: {e}"),
                 },
             ));
         }
@@ -145,20 +145,20 @@ where
         ExecutionResult::Revert { output, .. } => {
             return Err(BlockExecutionError::from(
                 GnosisBlockExecutionError::CustomErrorMessage {
-                    message: format!("block rewards contract system call revert {}", output),
+                    message: format!("block rewards contract system call revert {output}"),
                 },
             ));
         }
         ExecutionResult::Halt { reason, .. } => {
             return Err(BlockExecutionError::from(
                 GnosisBlockExecutionError::CustomErrorMessage {
-                    message: format!("block rewards contract system call halt {:?}", reason),
+                    message: format!("block rewards contract system call halt {reason:?}"),
                 },
             ));
         }
     };
 
-    let result = rewardCall::abi_decode_returns(output_bytes.as_ref(), true).map_err(|e| {
+    let result = rewardCall::abi_decode_returns(output_bytes.as_ref()).map_err(|e| {
         BlockExecutionError::from(GnosisBlockExecutionError::CustomErrorMessage {
             message: format!(
                 "error parsing block rewards contract system call return {:?}: {}",

--- a/src/gnosis.rs
+++ b/src/gnosis.rs
@@ -15,7 +15,6 @@ use revm::{
     context::result::{ExecutionResult, Output, ResultAndState},
     DatabaseCommit,
 };
-use revm_state::{Account, AccountInfo, AccountStatus};
 use std::fmt::Display;
 
 // Codegen from https://github.com/gnosischain/specs/blob/master/execution/withdrawals.md
@@ -111,7 +110,7 @@ fn apply_block_rewards_contract_call<SPEC>(
 where
     SPEC: EthExecutorSpec,
 {
-    let ResultAndState { result, mut state } = match evm.transact_system_call(
+    let ResultAndState { result, state } = match evm.transact_system_call(
         alloy_eips::eip4788::SYSTEM_ADDRESS,
         block_rewards_contract,
         rewardCall {
@@ -167,36 +166,6 @@ where
             ),
         })
     })?;
-
-    // in gnosis aura, system account needs to be included in the state and not removed (despite EIP-158/161, even if empty)
-    // here we have a generalized check if system account is in state, or needs to be created
-
-    // keeping this generalized, instead of only in block 1
-    // (AccountStatus::Touched | AccountStatus::LoadedAsNotExisting) means the account is not in the state
-    let should_create =
-        state
-            .get(&alloy_eips::eip4788::SYSTEM_ADDRESS)
-            .is_none_or(|system_account| {
-                // true if account not in state (either None, or Touched | LoadedAsNotExisting)
-                system_account.status
-                    == (AccountStatus::Touched | AccountStatus::LoadedAsNotExisting)
-            });
-
-    // this check needs to be there in every call, so instead of making it into a function which is called from post_execution, we can just include it in the rewards function
-    if should_create {
-        let account = Account {
-            info: AccountInfo::default(),
-            storage: Default::default(),
-            // we force the account to be created by changing the status
-            status: AccountStatus::Touched | AccountStatus::Created,
-        };
-        state.insert(alloy_eips::eip4788::SYSTEM_ADDRESS, account);
-    } else {
-        // clear the system address account from state transitions, else EIP-158/161 (impl in revm) removes it from state
-        state.remove(&alloy_eips::eip4788::SYSTEM_ADDRESS);
-    }
-
-    state.remove(&evm.block().beneficiary);
 
     system_caller.invoke_hook_with(|hook| {
         hook.on_state(

--- a/src/initialize/download_init_state.rs
+++ b/src/initialize/download_init_state.rs
@@ -208,7 +208,7 @@ pub async fn ensure_state(data_dir: &Path, chain: &str) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    println!("🛠   combining chunks → {}", STATE_FILE);
+    println!("🛠   combining chunks → {STATE_FILE}");
     let tmp = state_path.with_extension("part");
     let mut out = fs::File::create(&tmp).await?;
     for idx in 0..get_chunks(chain).len() {

--- a/src/initialize/import_and_ensure_state.rs
+++ b/src/initialize/import_and_ensure_state.rs
@@ -110,7 +110,7 @@ pub fn download_and_import_init_state(
             return;
         } else {
             println!("❌ State looks misconfigured, please delete the following directory and try again:");
-            println!("{:?}", datadir);
+            println!("{datadir:?}");
             std::process::exit(1);
         }
     }

--- a/src/payload_builder.rs
+++ b/src/payload_builder.rs
@@ -4,8 +4,8 @@ use reth_ethereum_engine_primitives::{
 use reth_ethereum_payload_builder::EthereumBuilderConfig;
 use reth_evm::ConfigureEvm;
 use reth_node_builder::{
-    components::PayloadBuilderBuilder, BuilderContext, FullNodeTypes, NodeTypesWithEngine,
-    PayloadTypes, PrimitivesTy, TxTy,
+    components::PayloadBuilderBuilder, BuilderContext, FullNodeTypes, NodeTypes, PayloadTypes,
+    PrimitivesTy, TxTy,
 };
 use reth_primitives::EthPrimitives;
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
@@ -27,17 +27,20 @@ impl GnosisPayloadBuilder {
         pool: Pool,
     ) -> eyre::Result<crate::payload::GnosisPayloadBuilder<Pool, Node::Provider, Evm>>
     where
-        Types: NodeTypesWithEngine<ChainSpec = GnosisChainSpec, Primitives = EthPrimitives>,
+        Types: NodeTypes<
+            ChainSpec = GnosisChainSpec,
+            Primitives = EthPrimitives,
+            Payload: PayloadTypes<
+                BuiltPayload = EthBuiltPayload,
+                PayloadAttributes = EthPayloadAttributes,
+                PayloadBuilderAttributes = EthPayloadBuilderAttributes,
+            >,
+        >,
         Node: FullNodeTypes<Types = Types>,
         Evm: ConfigureEvm<Primitives = PrimitivesTy<Types>>,
         Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
             + Unpin
             + 'static,
-        Types::Engine: PayloadTypes<
-            BuiltPayload = EthBuiltPayload,
-            PayloadAttributes = EthPayloadAttributes,
-            PayloadBuilderAttributes = EthPayloadBuilderAttributes,
-        >,
     {
         let chain_spec = ctx.chain_spec();
 
@@ -55,16 +58,19 @@ impl GnosisPayloadBuilder {
 
 impl<Types, Node, Pool> PayloadBuilderBuilder<Node, Pool> for GnosisPayloadBuilder
 where
-    Types: NodeTypesWithEngine<ChainSpec = GnosisChainSpec, Primitives = EthPrimitives>,
+    Types: NodeTypes<
+        ChainSpec = GnosisChainSpec,
+        Primitives = EthPrimitives,
+        Payload: PayloadTypes<
+            BuiltPayload = EthBuiltPayload,
+            PayloadAttributes = EthPayloadAttributes,
+            PayloadBuilderAttributes = EthPayloadBuilderAttributes,
+        >,
+    >,
     Node: FullNodeTypes<Types = Types>,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
         + Unpin
         + 'static,
-    Types::Engine: PayloadTypes<
-        BuiltPayload = EthBuiltPayload,
-        PayloadAttributes = EthPayloadAttributes,
-        PayloadBuilderAttributes = EthPayloadBuilderAttributes,
-    >,
 {
     type PayloadBuilder =
         crate::payload::GnosisPayloadBuilder<Pool, Node::Provider, GnosisEvmConfig>;

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,6 +1,6 @@
 use reth_node_builder::{
     components::PoolBuilder,
-    node::{FullNodeTypes, NodeTypesWithEngine},
+    node::{FullNodeTypes, NodeTypes},
     BuilderContext,
 };
 use reth_primitives::EthPrimitives;
@@ -16,7 +16,7 @@ pub struct GnosisPoolBuilder {}
 
 impl<Types, Node> PoolBuilder<Node> for GnosisPoolBuilder
 where
-    Types: NodeTypesWithEngine<ChainSpec = GnosisChainSpec, Primitives = EthPrimitives>,
+    Types: NodeTypes<ChainSpec = GnosisChainSpec, Primitives = EthPrimitives>,
     Node: FullNodeTypes<Types = Types>,
 {
     type Pool = EthTransactionPool<Node::Provider, DiskFileBlobStore>;

--- a/src/spec/gnosis_spec.rs
+++ b/src/spec/gnosis_spec.rs
@@ -17,8 +17,6 @@ use reth_evm::eth::spec::EthExecutorSpec;
 use reth_network_peers::{parse_nodes, NodeRecord};
 use reth_primitives::SealedHeader;
 use revm_primitives::{b256, Address, B256, U256};
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Eq)]
 enum Chain {

--- a/src/testing/cases/blockchain_test.rs
+++ b/src/testing/cases/blockchain_test.rs
@@ -62,11 +62,11 @@ impl Case for BlockchainTestCase {
                     path: path.into(),
                     error,
                 })?;
-                
+
                 serde_json::from_str(&s).map_err(|error| Error::CouldNotDeserialize {
-                        path: path.into(),
-                        error,
-                    })?
+                    path: path.into(),
+                    error,
+                })?
             },
             skip: should_skip(path),
         })

--- a/src/testing/cases/blockchain_test.rs
+++ b/src/testing/cases/blockchain_test.rs
@@ -62,12 +62,11 @@ impl Case for BlockchainTestCase {
                     path: path.into(),
                     error,
                 })?;
-                let test =
-                    serde_json::from_str(&s).map_err(|error| Error::CouldNotDeserialize {
+                
+                serde_json::from_str(&s).map_err(|error| Error::CouldNotDeserialize {
                         path: path.into(),
                         error,
-                    })?;
-                test
+                    })?
             },
             skip: should_skip(path),
         })
@@ -200,7 +199,7 @@ impl Case for BlockchainTestCase {
                 );
                 if let Err(e) = result {
                     return Err(Error::Custom(
-                        format!("error in execution stage {:?}", e).to_string(),
+                        format!("error in execution stage {e:?}").to_string(),
                     ));
                 }
 


### PR DESCRIPTION
migrate all api changes since 1.3.0 

we have an upcoming release next week which also includes a few additional evm/builder related changes but we're stabilizing a bit on tht front now.

to reduce friction I can update this pr next week