### PR TITLE
fix: update ethereum/tests clone command to checkout specific tag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
           toolchain: ${{ matrix.rust || 'stable' }}
           targets: ${{ matrix.target }}
       - name: Downloading ethereum/tests
-        run: git clone https://github.com/ethereum/tests ethereum-tests
+        run: git clone https://github.com/ethereum/tests ethereum-tests && cd ethereum-tests && git checkout tags/v17.0 && cd ..
       - name: Downloading EELS fixtures released at Cancun
         run: curl -LO https://github.com/ethereum/execution-spec-tests/releases/download/v2.1.1/fixtures.tar.gz && tar -xzf fixtures.tar.gz
       - name: Test specs (EELS and ethereum/tests)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
           toolchain: ${{ matrix.rust || 'stable' }}
           targets: ${{ matrix.target }}
       - name: Downloading ethereum/tests
-        run: git clone https://github.com/ethereum/tests ethereum-tests && cd ethereum-tests && git checkout tags/v17.0 && cd ..
+        run: git clone --branch v17.0 --depth 1 https://github.com/ethereum/tests ethereum-tests
       - name: Downloading EELS fixtures released at Cancun
         run: curl -LO https://github.com/ethereum/execution-spec-tests/releases/download/v2.1.1/fixtures.tar.gz && tar -xzf fixtures.tar.gz
       - name: Test specs (EELS and ethereum/tests)


### PR DESCRIPTION
This was necessary due to test fillers being removed in latest version