### PR TITLE
feat: implement Gnosis block execution ctx for header lookup

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use alloy_consensus::{Transaction, TxReceipt};
+use alloy_eips::eip4895::Withdrawals;
 use alloy_eips::eip7002::WITHDRAWAL_REQUEST_TYPE;
 use alloy_eips::eip7251;
 use alloy_eips::{eip7685::Requests, Encodable2718};
@@ -11,6 +12,7 @@ use alloy_evm::{
     FromTxWithEncoded,
 };
 use alloy_evm::{Database, Evm};
+use alloy_primitives::B256;
 use reth_chainspec::EthereumHardforks;
 use reth_errors::{BlockExecutionError, BlockValidationError};
 use reth_evm::{
@@ -21,7 +23,6 @@ use reth_evm::{
     eth::{
         receipt_builder::{AlloyReceiptBuilder, ReceiptBuilder, ReceiptBuilderCtx},
         spec::EthExecutorSpec,
-        EthBlockExecutionCtx,
     },
     EvmFactory, FromRecoveredTx, OnStateHook,
 };
@@ -35,15 +36,29 @@ use crate::evm::factory::GnosisEvmFactory;
 use crate::gnosis::apply_post_block_system_calls;
 use crate::spec::gnosis_spec::GnosisChainSpec;
 
+/// Gnosis-specific block execution context.
+/// Extends the standard Ethereum context with parent timestamp for hardfork activation checks.
+#[derive(Debug, Clone)]
+pub struct GnosisBlockExecutionCtx<'a> {
+    /// Hash of the parent block.
+    pub parent_hash: B256,
+    /// Parent beacon block root (for EIP-4788).
+    pub parent_beacon_block_root: Option<B256>,
+    /// Withdrawals for this block.
+    pub withdrawals: Option<Cow<'a, Withdrawals>>,
+    /// Parent block timestamp - used for detecting hardfork activation boundaries.
+    pub parent_timestamp: u64,
+}
+
 // REF: https://github.com/alloy-rs/evm/blob/99d5b552c131e3419448c214e09474bf4f0d1e4b/crates/op-evm/src/block/mod.rs#L42
-/// Block executor for Ethereum.
+/// Block executor for Gnosis.
 #[derive(Debug)]
 pub struct GnosisBlockExecutor<'a, Evm, R: ReceiptBuilder> {
     /// Reference to the specification object.
     spec: GnosisChainSpec,
 
     /// Context for block execution.
-    pub ctx: EthBlockExecutionCtx<'a>,
+    pub ctx: GnosisBlockExecutionCtx<'a>,
     /// Inner EVM.
     evm: Evm,
     /// Utility to call system smart contracts.
@@ -67,7 +82,7 @@ where
     /// Creates a new [`GnosisBlockExecutor`]
     pub fn new(
         evm: Evm,
-        ctx: EthBlockExecutionCtx<'a>,
+        ctx: GnosisBlockExecutionCtx<'a>,
         spec: &GnosisChainSpec,
         receipt_builder: R,
         block_rewards_address: Address,
@@ -323,7 +338,7 @@ where
     Self: 'static,
 {
     type EvmFactory = EvmF;
-    type ExecutionCtx<'a> = EthBlockExecutionCtx<'a>;
+    type ExecutionCtx<'a> = GnosisBlockExecutionCtx<'a>;
     type Transaction = R::Transaction;
     type Receipt = R::Receipt;
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -9,14 +9,13 @@ use reth_errors::BlockExecutionError;
 use reth_ethereum_primitives::Receipt;
 use reth_evm::{
     block::BlockExecutorFactory,
-    eth::EthBlockExecutionCtx,
     execute::{BlockAssembler, BlockAssemblerInput},
 };
 use reth_primitives::TransactionSigned;
 use reth_primitives_traits::logs_bloom;
 use reth_provider::BlockExecutionResult;
 
-use crate::primitives::block::GnosisBlock;
+use crate::{block::GnosisBlockExecutionCtx, primitives::block::GnosisBlock};
 
 /// Block builder for Gnosis.
 #[derive(Debug)]
@@ -50,7 +49,7 @@ impl<ChainSpec> Clone for GnosisBlockAssembler<ChainSpec> {
 impl<F, ChainSpec> BlockAssembler<F> for GnosisBlockAssembler<ChainSpec>
 where
     F: for<'a> BlockExecutorFactory<
-        ExecutionCtx<'a> = EthBlockExecutionCtx<'a>,
+        ExecutionCtx<'a> = GnosisBlockExecutionCtx<'a>,
         Transaction = TransactionSigned,
         Receipt = Receipt,
     >,

--- a/src/cli/gnosis_cli.rs
+++ b/src/cli/gnosis_cli.rs
@@ -25,7 +25,7 @@ use reth_tracing::FileWorkerGuard;
 use tracing::info;
 
 use crate::{
-    evm_config::GnosisEvmConfig,
+    evm_config::{GnosisEvmConfig, NoopHeaderLookup},
     primitives::GnosisNodePrimitives,
     spec::gnosis_spec::{GnosisChainSpec, GnosisChainSpecParser},
     GnosisNode,
@@ -134,7 +134,7 @@ where
     {
         let components = |spec: Arc<C::ChainSpec>| {
             (
-                GnosisEvmConfig::new(spec.clone()),
+                GnosisEvmConfig::new(spec.clone(), NoopHeaderLookup),
                 Arc::new(EthBeaconConsensus::new(spec))
                     as Arc<dyn FullConsensus<GnosisNodePrimitives, Error = ConsensusError>>,
             )
@@ -150,7 +150,7 @@ where
     pub fn with_runner_and_components(
         mut self,
         runner: CliRunner,
-        _components: impl CliComponentsBuilder<GnosisNode>,
+        components: impl CliComponentsBuilder<GnosisNode>,
         launcher: impl AsyncFnOnce(
             WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, C::ChainSpec>>,
             Ext,
@@ -186,7 +186,8 @@ where
             Commands::Db(command) => {
                 runner.run_blocking_until_ctrl_c(command.execute::<GnosisNode>())
             }
-            Commands::Stage(_command) => unimplemented!(),
+            Commands::Stage(command) => runner
+                .run_command_until_exit(|ctx| command.execute::<GnosisNode, _>(ctx, components)),
             Commands::P2P(_command) => unimplemented!(),
             Commands::Config(command) => runner.run_until_ctrl_c(command.execute()),
             Commands::Prune(command) => runner.run_until_ctrl_c(command.execute::<GnosisNode>()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use reth_node_builder::{
     PayloadAttributesBuilder, PayloadTypes,
 };
 use reth_node_ethereum::EthereumEthApiBuilder;
-use reth_provider::EthStorage;
+use reth_provider::{EthStorage, HeaderProvider};
 use spec::gnosis_spec::GnosisChainSpec;
 use std::sync::Arc;
 
@@ -181,12 +181,13 @@ impl<Node> ExecutorBuilder<Node> for GnosisExecutorBuilder
 where
     Node: FullNodeTypes<
         Types: NodeTypes<ChainSpec = GnosisChainSpec, Primitives = GnosisNodePrimitives>,
+        Provider: HeaderProvider<Header = GnosisHeader> + std::fmt::Debug + Clone + Unpin + 'static,
     >,
 {
     type EVM = GnosisEvmConfig;
 
     async fn build_evm(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::EVM> {
-        let evm_config = GnosisEvmConfig::new(ctx.chain_spec());
+        let evm_config = GnosisEvmConfig::new(ctx.chain_spec(), ctx.provider().clone());
 
         Ok(evm_config)
     }


### PR DESCRIPTION
current block exec context doesn't have any info of the parent except the hash. this is meant to enable looking up the parent header. this is in preparation for an upcoming hardfork where parent-timestamp will be used to determine execution path.