### PR TITLE
fix: Cargo.toml to use branch v1.9.3-gnosis for reth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3598,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "gnosis-primitives"
 version = "0.1.8"
-source = "git+https://github.com/gnosischain/gnosis-stuff.git?tag=v0.1.9#e0f0c65e3756d1c3e3a281b8d3d121c84828ea82"
+source = "git+https://github.com/gnosischain/gnosis-stuff.git?tag=v0.1.91#0a42e804550a6a1eebd9b31eda6eeff180216684"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6418,7 +6418,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -6464,7 +6464,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6488,7 +6488,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6519,7 +6519,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6539,7 +6539,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -6553,7 +6553,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6628,7 +6628,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -6638,7 +6638,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6656,7 +6656,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6676,7 +6676,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6686,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -6701,7 +6701,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6714,7 +6714,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6726,7 +6726,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6752,7 +6752,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -6778,7 +6778,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6806,7 +6806,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6836,7 +6836,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6851,7 +6851,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6876,7 +6876,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6900,7 +6900,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -6924,7 +6924,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6955,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -6986,7 +6986,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7008,7 +7008,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "futures",
  "pin-project",
@@ -7055,7 +7055,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7105,7 +7105,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7133,7 +7133,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7149,7 +7149,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7164,7 +7164,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7186,7 +7186,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7197,7 +7197,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7225,7 +7225,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7246,7 +7246,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "clap",
  "eyre",
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7286,7 +7286,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7304,7 +7304,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -7317,7 +7317,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7346,7 +7346,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7366,7 +7366,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -7376,7 +7376,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7399,7 +7399,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7420,7 +7420,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -7433,7 +7433,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7451,7 +7451,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7489,7 +7489,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7503,7 +7503,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "serde",
  "serde_json",
@@ -7513,7 +7513,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7541,7 +7541,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "bytes",
  "futures",
@@ -7561,7 +7561,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -7577,7 +7577,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -7586,7 +7586,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "futures",
  "metrics",
@@ -7598,7 +7598,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-primitives",
 ]
@@ -7606,7 +7606,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -7620,7 +7620,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7675,7 +7675,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7700,7 +7700,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7722,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7737,7 +7737,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -7751,7 +7751,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -7768,7 +7768,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -7792,7 +7792,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7860,7 +7860,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7913,7 +7913,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -7951,7 +7951,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7975,7 +7975,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7999,7 +7999,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "eyre",
  "http",
@@ -8021,7 +8021,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8033,7 +8033,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8053,7 +8053,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8074,7 +8074,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -8086,7 +8086,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8106,7 +8106,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8116,7 +8116,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "c-kzg",
@@ -8130,7 +8130,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8163,7 +8163,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8207,7 +8207,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8234,7 +8234,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8249,7 +8249,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8268,7 +8268,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8295,7 +8295,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -8308,7 +8308,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8387,7 +8387,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -8415,7 +8415,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -8454,7 +8454,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -8475,7 +8475,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8505,7 +8505,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8549,7 +8549,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8596,7 +8596,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -8610,7 +8610,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8626,7 +8626,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8670,7 +8670,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8697,7 +8697,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8711,7 +8711,7 @@ dependencies = [
 [[package]]
 name = "reth-stateless"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8738,7 +8738,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -8758,7 +8758,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -8770,7 +8770,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8793,7 +8793,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8809,7 +8809,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -8827,7 +8827,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -8837,7 +8837,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "clap",
  "eyre",
@@ -8854,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "clap",
  "eyre",
@@ -8871,7 +8871,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8911,7 +8911,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8936,7 +8936,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8963,7 +8963,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -8976,7 +8976,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9001,7 +9001,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9020,7 +9020,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9038,7 +9038,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
+source = "git+https://github.com/paradigmxyz/reth?branch=v1.9.3-gnosis#614be716b939fa3f334158e098dacf23cb4e1f84"
 dependencies = [
  "zstd 0.13.3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,60 +12,60 @@ name = "reth"
 path = "src/main.rs"
 
 [dependencies]
-gnosis-primitives = { git = "https://github.com/gnosischain/gnosis-stuff.git", tag = "v0.1.9" }
+gnosis-primitives = { git = "https://github.com/gnosischain/gnosis-stuff.git", tag = "v0.1.91" }
 
-reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-fs-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-db-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-era = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-era-downloader = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-era-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3", features = [
+reth = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-fs-util = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-db-common = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-era = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-era-downloader = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-era-utils = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis", features = [
     "test-utils",
 ] }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-stages-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-stages-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-stateless = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-stages-api = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-stages-types = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-stateless = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
 
 eyre = "0.6"
 clap = { version = "4.5.6", features = ["derive"] }


### PR DESCRIPTION
### critical fix

due to a bug in upstream reth, header-stage unwinds cause panic (for custom header types). this is because the default type for `HeaderStage::unwind` still uses the `alloy_consensus::Header` (eth header), instead of the `HeaderTy` implemented for `NodePrimitives`

since 1.9.3 is the latest release, and the reth:main branch is not stabilized yet, they have cherry-picked the fix on top of 1.9.3 in this commit: https://github.com/paradigmxyz/reth/pull/20250

the diff between reth branches v1.9.3 and v1.9.3-gnosis is: https://github.com/paradigmxyz/reth/compare/v1.9.3...v1.9.3-gnosis?expand=1

update to gnosis-primitives also includes the exact same change: https://github.com/gnosischain/gnosis-stuff/compare/v0.1.9...v0.1.91

