### PR TITLE
fix: modified the header-serde to return hex string responses for RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3597,13 +3597,14 @@ dependencies = [
 
 [[package]]
 name = "gnosis-primitives"
-version = "0.1.8"
-source = "git+https://github.com/gnosischain/gnosis-stuff.git?tag=v0.1.91#0a42e804550a6a1eebd9b31eda6eeff180216684"
+version = "0.1.93"
+source = "git+https://github.com/gnosischain/gnosis-stuff.git?tag=v0.1.93#3392be766cdf3455616eb57d0db4c80028bb4213"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-serde",
  "alloy-trie",
  "derive_more",
  "modular-bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "reth"
 path = "src/main.rs"
 
 [dependencies]
-gnosis-primitives = { git = "https://github.com/gnosischain/gnosis-stuff.git", tag = "v0.1.91" }
+gnosis-primitives = { git = "https://github.com/gnosischain/gnosis-stuff.git", tag = "v0.1.93" }
 
 reth = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }
 reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "v1.9.3-gnosis" }


### PR DESCRIPTION
makes serde always-on instead of optional inside gnosis-primitives

fixes an issue which causes RPC requests to return integers (number: 0) instead of hex-strings (number: "0x0")