### PR TITLE
feat: unified versioning

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Git pre-push hook to validate version before pushing tags
+# Install with: git config core.hooksPath .githooks
+
+while read local_ref local_sha remote_ref remote_sha; do
+    # Check if pushing a tag
+    if [[ "$local_ref" == refs/tags/v* ]]; then
+        TAG_NAME="${local_ref#refs/tags/}"
+        TAG_VERSION="${TAG_NAME#v}"
+
+        CARGO_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+
+        if [ "$CARGO_VERSION" != "$TAG_VERSION" ]; then
+            echo "ERROR: Cannot push tag $TAG_NAME"
+            echo "Cargo.toml version ($CARGO_VERSION) does not match tag version ($TAG_VERSION)"
+            echo ""
+            echo "Please update Cargo.toml:"
+            echo "  sed -i '' 's/^version = .*/version = \"$TAG_VERSION\"/' Cargo.toml"
+            echo ""
+            echo "Then amend your tag:"
+            echo "  git tag -d $TAG_NAME"
+            echo "  git commit -am 'chore: bump version to $TAG_VERSION'"
+            echo "  git tag $TAG_NAME"
+            exit 1
+        fi
+
+        echo "Version check passed for tag $TAG_NAME"
+    fi
+done
+
+exit 0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9221,7 +9221,7 @@ dependencies = [
 
 [[package]]
 name = "reth_gnosis"
-version = "0.1.0"
+version = "1.0.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9313,6 +9313,8 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tracing",
+ "vergen",
+ "vergen-git2",
  "walkdir",
  "zstd 0.12.4",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth_gnosis"
-version = "0.1.0"
+version = "1.0.2"
 edition = "2021"
 
 [lib]
@@ -128,3 +128,7 @@ jemalloc = ["dep:tikv-jemallocator"]
 testing = []
 failing-tests = []
 serde = []
+
+[build-dependencies]
+vergen = { version = "9.1.0", features = ["build", "cargo", "emit_and_set"] }
+vergen-git2 = "9.1.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,116 @@
+//! Build script for reth_gnosis - sets version info at compile time.
+//! All env vars set here are available via env!() macros in src/ code.
+
+use std::env;
+use vergen::{BuildBuilder, CargoBuilder, Emitter};
+use vergen_git2::Git2Builder;
+
+/// The upstream reth version this build is based on.
+/// Update this when bumping reth dependencies in Cargo.toml.
+const RETH_UPSTREAM_VERSION: &str = "1.10.2";
+
+fn main() {
+    // Always set the upstream version
+    println!("cargo:rustc-env=RETH_UPSTREAM_VERSION={RETH_UPSTREAM_VERSION}");
+
+    // Try to get git/build info, fall back to defaults if unavailable
+    if let Err(e) = try_set_version_info() {
+        eprintln!("Warning: Could not get git info: {e}. Using fallback values.");
+        set_fallback_version_info();
+    }
+}
+
+fn try_set_version_info() -> Result<(), Box<dyn std::error::Error>> {
+    let mut emitter = Emitter::default();
+
+    let build = BuildBuilder::default().build_timestamp(true).build()?;
+    emitter.add_instructions(&build)?;
+
+    let cargo = CargoBuilder::default().features(true).target_triple(true).build()?;
+    emitter.add_instructions(&cargo)?;
+
+    let git = Git2Builder::default()
+        .describe(false, true, None)
+        .dirty(true)
+        .sha(false)
+        .build()?;
+    emitter.add_instructions(&git)?;
+
+    emitter.emit_and_set()?;
+
+    let sha = env::var("VERGEN_GIT_SHA")?;
+    let sha_short = &sha[0..8];
+
+    let is_dirty = env::var("VERGEN_GIT_DIRTY")? == "true";
+    // > git describe --always --tags
+    // if not on a tag: v0.2.0-beta.3-82-g1939939b
+    // if on a tag: v0.2.0-beta.3
+    let not_on_tag = env::var("VERGEN_GIT_DESCRIBE")?.ends_with(&format!("-g{}", &sha[0..7]));
+    let version_suffix = if is_dirty || not_on_tag { "-dev" } else { "" };
+
+    // Set short SHA
+    println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT={sha_short}");
+
+    // Set the build profile
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let profile = out_dir
+        .rsplit(std::path::MAIN_SEPARATOR)
+        .nth(3)
+        .unwrap_or("unknown");
+    println!("cargo:rustc-env=RETH_GNOSIS_BUILD_PROFILE={profile}");
+
+    let pkg_version = env!("CARGO_PKG_VERSION");
+
+    // Short version: "1.0.2-dev (abc12345)"
+    let short_version = format!("{pkg_version}{version_suffix} ({sha_short})");
+    println!("cargo:rustc-env=RETH_GNOSIS_SHORT_VERSION={short_version}");
+
+    // Print version info to build logs for visibility
+    println!("cargo:warning=Building reth_gnosis {short_version}");
+    println!("cargo:warning=  Based on: reth {RETH_UPSTREAM_VERSION}");
+    println!("cargo:warning=  Git SHA: {sha}");
+    println!("cargo:warning=  Profile: {profile}");
+
+    // Long version lines
+    println!("cargo:rustc-env=RETH_GNOSIS_LONG_VERSION_0=Version: {pkg_version}{version_suffix}");
+    println!("cargo:rustc-env=RETH_GNOSIS_LONG_VERSION_1=Commit SHA: {sha}");
+    println!(
+        "cargo:rustc-env=RETH_GNOSIS_LONG_VERSION_2=Build Timestamp: {}",
+        env::var("VERGEN_BUILD_TIMESTAMP")?
+    );
+    println!(
+        "cargo:rustc-env=RETH_GNOSIS_LONG_VERSION_3=Build Features: {}",
+        env::var("VERGEN_CARGO_FEATURES")?
+    );
+    println!("cargo:rustc-env=RETH_GNOSIS_LONG_VERSION_4=Build Profile: {profile}");
+
+    // P2P client version: "reth_gnosis/v1.0.2-abc12345/aarch64-apple-darwin"
+    let target = env::var("VERGEN_CARGO_TARGET_TRIPLE")?;
+    println!(
+        "cargo:rustc-env=RETH_GNOSIS_P2P_CLIENT_VERSION=reth_gnosis/v{pkg_version}-{sha_short}/{target}"
+    );
+
+    Ok(())
+}
+
+fn set_fallback_version_info() {
+    let pkg_version = env!("CARGO_PKG_VERSION");
+
+    // Print fallback info to build logs
+    println!("cargo:warning=Building reth_gnosis {pkg_version} (unknown) [fallback - no git info]");
+    println!("cargo:warning=  Based on: reth {RETH_UPSTREAM_VERSION}");
+
+    println!("cargo:rustc-env=VERGEN_GIT_SHA=unknown");
+    println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT=unknown");
+    println!("cargo:rustc-env=VERGEN_BUILD_TIMESTAMP=unknown");
+    println!("cargo:rustc-env=VERGEN_CARGO_TARGET_TRIPLE=unknown");
+    println!("cargo:rustc-env=VERGEN_CARGO_FEATURES=unknown");
+    println!("cargo:rustc-env=RETH_GNOSIS_BUILD_PROFILE=unknown");
+    println!("cargo:rustc-env=RETH_GNOSIS_SHORT_VERSION={pkg_version} (unknown)");
+    println!("cargo:rustc-env=RETH_GNOSIS_LONG_VERSION_0=Version: {pkg_version}");
+    println!("cargo:rustc-env=RETH_GNOSIS_LONG_VERSION_1=Commit SHA: unknown");
+    println!("cargo:rustc-env=RETH_GNOSIS_LONG_VERSION_2=Build Timestamp: unknown");
+    println!("cargo:rustc-env=RETH_GNOSIS_LONG_VERSION_3=Build Features: unknown");
+    println!("cargo:rustc-env=RETH_GNOSIS_LONG_VERSION_4=Build Profile: unknown");
+    println!("cargo:rustc-env=RETH_GNOSIS_P2P_CLIENT_VERSION=reth_gnosis/v{pkg_version}-unknown/unknown");
+}

--- a/build.rs
+++ b/build.rs
@@ -26,7 +26,10 @@ fn try_set_version_info() -> Result<(), Box<dyn std::error::Error>> {
     let build = BuildBuilder::default().build_timestamp(true).build()?;
     emitter.add_instructions(&build)?;
 
-    let cargo = CargoBuilder::default().features(true).target_triple(true).build()?;
+    let cargo = CargoBuilder::default()
+        .features(true)
+        .target_triple(true)
+        .build()?;
     emitter.add_instructions(&cargo)?;
 
     let git = Git2Builder::default()
@@ -112,5 +115,7 @@ fn set_fallback_version_info() {
     println!("cargo:rustc-env=RETH_GNOSIS_LONG_VERSION_2=Build Timestamp: unknown");
     println!("cargo:rustc-env=RETH_GNOSIS_LONG_VERSION_3=Build Features: unknown");
     println!("cargo:rustc-env=RETH_GNOSIS_LONG_VERSION_4=Build Profile: unknown");
-    println!("cargo:rustc-env=RETH_GNOSIS_P2P_CLIENT_VERSION=reth_gnosis/v{pkg_version}-unknown/unknown");
+    println!(
+        "cargo:rustc-env=RETH_GNOSIS_P2P_CLIENT_VERSION=reth_gnosis/v{pkg_version}-unknown/unknown"
+    );
 }

--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Validates that Cargo.toml version matches a git tag
+set -e
+
+TAG_VERSION="${1#v}"  # Strip leading 'v' if present
+
+if [ -z "$TAG_VERSION" ]; then
+    echo "Usage: $0 <tag-version>"
+    echo "Example: $0 v1.0.2"
+    exit 1
+fi
+
+CARGO_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+
+if [ "$CARGO_VERSION" != "$TAG_VERSION" ]; then
+    echo "ERROR: Cargo.toml version ($CARGO_VERSION) does not match tag version ($TAG_VERSION)"
+    echo ""
+    echo "Please update Cargo.toml version to $TAG_VERSION before tagging."
+    exit 1
+fi
+
+echo "Version check passed: $CARGO_VERSION"

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
+use crate::version::default_gnosis_extra_data_bytes;
 use alloy_consensus::{proofs, BlockBody, BlockHeader, Header, TxReceipt, EMPTY_OMMER_ROOT_HASH};
 use alloy_eips::merge::BEACON_NONCE;
 use alloy_primitives::Bytes;
-use crate::version::default_gnosis_extra_data_bytes;
 use gnosis_primitives::header::GnosisHeader;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_errors::BlockExecutionError;

--- a/src/build.rs
+++ b/src/build.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use alloy_consensus::{proofs, BlockBody, BlockHeader, Header, TxReceipt, EMPTY_OMMER_ROOT_HASH};
 use alloy_eips::merge::BEACON_NONCE;
 use alloy_primitives::Bytes;
+use crate::version::default_gnosis_extra_data_bytes;
 use gnosis_primitives::header::GnosisHeader;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_errors::BlockExecutionError;
@@ -31,7 +32,7 @@ impl<ChainSpec> GnosisBlockAssembler<ChainSpec> {
     pub fn new(chain_spec: Arc<ChainSpec>) -> Self {
         Self {
             chain_spec,
-            extra_data: Bytes::from("reth_gnosis@v1.0.1".as_bytes().to_vec()),
+            extra_data: default_gnosis_extra_data_bytes(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ mod primitives;
 mod rpc;
 pub mod spec;
 mod testing;
+pub mod version;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, clap::Args)]
 #[command(next_help_heading = "Gnosis")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,10 @@ use reth_gnosis::consts::{DEFAULT_7702_PATCH_TIME, DEFAULT_EL_PATCH_TIME};
 use reth_gnosis::initialize::download_init_state::{CHIADO_DOWNLOAD_SPEC, GNOSIS_DOWNLOAD_SPEC};
 use reth_gnosis::initialize::import_and_ensure_state::download_and_import_init_state;
 use reth_gnosis::{
-    cli::gnosis_cli::GnosisCli, spec::gnosis_spec::GnosisChainSpecParser, GnosisNode,
+    cli::gnosis_cli::GnosisCli, spec::gnosis_spec::GnosisChainSpecParser,
+    version::{default_gnosis_extra_data, init_gnosis_version, RETH_UPSTREAM_VERSION}, GnosisNode,
 };
+use tracing::info;
 
 // We use jemalloc for performance reasons
 #[cfg(all(feature = "jemalloc", unix))]
@@ -23,8 +25,15 @@ pub struct NoArgs;
 type CliGnosis = GnosisCli<GnosisChainSpecParser, NoArgs>;
 
 fn main() {
+    // MUST be called before CLI parsing to override reth's version metadata
+    init_gnosis_version();
+
     let user_cli = CliGnosis::parse();
     let _guard = user_cli.init_tracing();
+
+    // Log upstream reth version once at startup
+    info!(target: "reth::cli", "Based on reth {}", RETH_UPSTREAM_VERSION);
+    info!(target: "reth::cli", "Block extra_data: {}", default_gnosis_extra_data());
 
     let timestamp = env::var("GNOSIS_EL_PATCH_TIME")
         .unwrap_or(DEFAULT_EL_PATCH_TIME.to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,10 @@ use reth_gnosis::consts::{DEFAULT_7702_PATCH_TIME, DEFAULT_EL_PATCH_TIME};
 use reth_gnosis::initialize::download_init_state::{CHIADO_DOWNLOAD_SPEC, GNOSIS_DOWNLOAD_SPEC};
 use reth_gnosis::initialize::import_and_ensure_state::download_and_import_init_state;
 use reth_gnosis::{
-    cli::gnosis_cli::GnosisCli, spec::gnosis_spec::GnosisChainSpecParser,
-    version::{default_gnosis_extra_data, init_gnosis_version, RETH_UPSTREAM_VERSION}, GnosisNode,
+    cli::gnosis_cli::GnosisCli,
+    spec::gnosis_spec::GnosisChainSpecParser,
+    version::{default_gnosis_extra_data, init_gnosis_version, RETH_UPSTREAM_VERSION},
+    GnosisNode,
 };
 use tracing::info;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,11 @@ use reth_gnosis::{
     version::{default_gnosis_extra_data, init_gnosis_version, RETH_UPSTREAM_VERSION},
     GnosisNode,
 };
-use tracing::info;
 use reth_rpc::ValidationApi;
 use reth_rpc_api::servers::BlockSubmissionValidationApiServer;
 use reth_rpc_builder::{config::RethRpcServerConfig, RethRpcModule};
 use std::sync::Arc;
+use tracing::info;
 
 // We use jemalloc for performance reasons
 #[cfg(all(feature = "jemalloc", unix))]

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,49 @@
+//! Version information for reth_gnosis.
+
+use alloy_primitives::Bytes;
+use reth::version::{try_init_version_metadata, RethCliVersionConsts};
+use std::borrow::Cow;
+
+/// The upstream reth version this is based on
+pub const RETH_UPSTREAM_VERSION: &str = env!("RETH_UPSTREAM_VERSION");
+
+/// Initialize the global version metadata with reth_gnosis values.
+/// MUST be called BEFORE any code calls `version_metadata()`.
+pub fn init_gnosis_version() {
+    let _ = try_init_version_metadata(gnosis_version_metadata());
+}
+
+/// Create the gnosis-specific version metadata
+pub fn gnosis_version_metadata() -> RethCliVersionConsts {
+    RethCliVersionConsts {
+        name_client: Cow::Borrowed("reth_gnosis"),
+        cargo_pkg_version: Cow::Borrowed(env!("CARGO_PKG_VERSION")),
+        vergen_git_sha_long: Cow::Borrowed(env!("VERGEN_GIT_SHA")),
+        vergen_git_sha: Cow::Borrowed(env!("VERGEN_GIT_SHA_SHORT")),
+        vergen_build_timestamp: Cow::Borrowed(env!("VERGEN_BUILD_TIMESTAMP")),
+        vergen_cargo_target_triple: Cow::Borrowed(env!("VERGEN_CARGO_TARGET_TRIPLE")),
+        vergen_cargo_features: Cow::Borrowed(env!("VERGEN_CARGO_FEATURES")),
+        short_version: Cow::Borrowed(env!("RETH_GNOSIS_SHORT_VERSION")),
+        long_version: Cow::Owned(format!(
+            "{}\n{}\n{}\n{}\n{}",
+            env!("RETH_GNOSIS_LONG_VERSION_0"),
+            env!("RETH_GNOSIS_LONG_VERSION_1"),
+            env!("RETH_GNOSIS_LONG_VERSION_2"),
+            env!("RETH_GNOSIS_LONG_VERSION_3"),
+            env!("RETH_GNOSIS_LONG_VERSION_4"),
+        )),
+        build_profile_name: Cow::Borrowed(env!("RETH_GNOSIS_BUILD_PROFILE")),
+        p2p_client_version: Cow::Borrowed(env!("RETH_GNOSIS_P2P_CLIENT_VERSION")),
+        extra_data: Cow::Owned(default_gnosis_extra_data()),
+    }
+}
+
+/// Default extra_data for built blocks: "reth_gnosis/v{version}"
+pub fn default_gnosis_extra_data() -> String {
+    format!("reth_gnosis/v{}", env!("CARGO_PKG_VERSION"))
+}
+
+/// Default extra_data as Bytes
+pub fn default_gnosis_extra_data_bytes() -> Bytes {
+    Bytes::from(default_gnosis_extra_data().as_bytes().to_vec())
+}


### PR DESCRIPTION
**TL;DR**: Introduces a robust versioning and metadata system for reth_gnosis, ensuring that build, git, and upstream version are consistently tracked throughout the codebase and build process. It enforces stricter version validation during tag pushes, and updates the default block extra data to use the current package version automatically.

Vergen is also used by reth upstream to inject commit SHA and version details into the codebase.

---

**Versioning and build metadata system:**

* Added a new `build.rs` script that uses `vergen` and `vergen-git2` to inject build-time, git, and upstream version information as environment variables, which are then available throughout the Rust codebase. This includes short and long version strings, git SHA, build profile, and a formatted P2P client version string. Fallbacks are provided if git info is unavailable. (`build.rs`, [build.rsR1-R121](diffhunk://#diff-d0d98998092552a1d3259338c2c71e118a5b8343dd4703c0c7f552ada7f9cb42R1-R121))
* Introduced a new `src/version.rs` module to centralize version information. It provides functions to initialize global version metadata, generate gnosis-specific metadata, and create default block extra data strings/bytes based on the current package version. (`src/version.rs`, [src/version.rsR1-R49](diffhunk://#diff-7bb693ee02aca4d9c13232347bb4e13cfad03f9573a547515b43800096e5ce7fR1-R49))
* Updated the block assembler and CLI startup to use the new version metadata, ensuring that block `extra_data` and startup logs reflect the correct version and upstream info. (`src/build.rs`, [[1]](diffhunk://#diff-be833857e8bbf63e2cbb12410f1e722789c4dce3d8c1dde47a79af89e52c71dcR3) [[2]](diffhunk://#diff-be833857e8bbf63e2cbb12410f1e722789c4dce3d8c1dde47a79af89e52c71dcL34-R35); `src/main.rs`, [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL10-R15) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR30-R39)

**Version validation and enforcement:**

* Added a Git pre-push hook (`.githooks/pre-push`) and a shell script (`scripts/check-version.sh`) to validate that the git tag being pushed matches the version in `Cargo.toml`, preventing accidental mismatches and providing instructions for resolution. (`.githooks/pre-push`, [[1]](diffhunk://#diff-d98b367aa518731b4158dd028ca94d051dfe32fefe54c4affde19f591ebc5fb6R1-R31); `scripts/check-version.sh`, [[2]](diffhunk://#diff-85648afc6e55b7f4b3853431875e66ec160be3705a64fe250e9e607c47ee1fa9R1-R22)

**Dependency and version updates:**

* Updated the crate version in `Cargo.toml` to `1.0.2` and added `vergen` and `vergen-git2` as build dependencies to support the new metadata system. (`Cargo.toml`, [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R131-R134)
* Added the new `version` module to the crate's public exports in `src/lib.rs`. (`src/lib.rs`, [src/lib.rsR54](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R54))