### PR TITLE
chore: remove unused codepaths

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,94 +1,11 @@
-use std::{any::Any, collections::HashMap};
+use std::collections::HashMap;
 
-use alloy_consensus::{EthereumTxEnvelope, TxEip4844, TxEip7702};
-use alloy_primitives::{address, Address, Bytes};
-use reth_transaction_pool::error::PoolTransactionError;
+use alloy_primitives::{Address, Bytes};
 use revm_primitives::{hex::FromHex, KECCAK_EMPTY};
 use revm_state::Bytecode;
 use serde_json::{self, Value};
 
 use crate::spec::gnosis_spec::BalancerHardforkConfig;
-
-const BLACKLIST_SENDERS_COUNT: usize = 2;
-pub const BLACKLIST_SENDERS: [Address; BLACKLIST_SENDERS_COUNT] = [
-    // Example blacklisted address
-    address!("0x506d1f9efe24f0d47853adca907eb8d89ae03207"),
-    address!("0x491837cc85bbeab5f9b3110ad61f39d87f8ec618"),
-    // address!("0x41FAb0BB658EF4c3f76AbD8Ee5bca4611f7478d0"),
-];
-
-const BLACKLIST_CONTRACT_ADDRESSES_COUNT: usize = 5;
-pub const BLACKLIST_CONTRACT_ADDRESSES: [Address; BLACKLIST_CONTRACT_ADDRESSES_COUNT] = [
-    address!("0x5e7FA86cfdD10de6129e53377335b78BB34eaBD3"),
-    address!("0x234490fA3Cd6C899681C8E93Ba88e97183a71FE4"),
-    address!("0x49b5CE67B22b1D596842ca071ac3dA93eE593E11"),
-    address!("0x7b23c07A0BbBe652Bf7069c9c4143a2C85132166"),
-    address!("0x1Bdc1FebebF92BfFab3a2E49C5cF3B7e35a9E81E"),
-    // address!("0x0eA9cACa364E352360EA241136c88867D63b93cB"),
-    // address!("0x413cFF89C3f59F900BD9e36336543F4AEFfc2e54"),
-];
-
-pub fn is_sender_blacklisted(sender: &Address) -> bool {
-    BLACKLIST_SENDERS.contains(sender)
-}
-
-pub fn is_to_address_blacklisted(address: &Address) -> bool {
-    BLACKLIST_CONTRACT_ADDRESSES.contains(address)
-}
-
-/// Gnosis-specific transaction pool validation errors
-#[derive(Debug, thiserror::Error)]
-pub enum GnosisError {
-    /// Custom error message for Gnosis-specific validation
-    #[error("{message}")]
-    CustomValidation { message: String },
-}
-
-impl PoolTransactionError for GnosisError {
-    fn is_bad_transaction(&self) -> bool {
-        match self {
-            Self::CustomValidation { .. } => false, // Could be environmental
-        }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-}
-
-// Helper function to create a pool error with Gnosis-specific validation error
-impl GnosisError {
-    /// Creates a new custom validation error
-    pub fn custom(message: impl Into<String>) -> Self {
-        Self::CustomValidation {
-            message: message.into(),
-        }
-    }
-}
-
-// filter to use:
-// is_sender_blacklisted(&sender)
-//   || is_to_address_blacklisted(&to)
-//   || is_blacklisted_setcode(&pool_tx.transaction.clone().into_consensus())
-pub fn is_blacklisted_setcode(tx: &EthereumTxEnvelope<TxEip4844>) -> bool {
-    match tx {
-        EthereumTxEnvelope::Eip7702(signed_tx) => {
-            let TxEip7702 {
-                authorization_list, ..
-            } = signed_tx.tx();
-            for auth in authorization_list {
-                if is_sender_blacklisted(&auth.recover_authority().unwrap_or_default()) {
-                    return true;
-                }
-            }
-            false
-        }
-        _ => false,
-    }
-}
-
-pub const DEFAULT_EL_PATCH_TIME: &str = "1762349400";
-pub const DEFAULT_7702_PATCH_TIME: &str = "1762522200";
 
 pub fn parse_balancer_hardfork_config(
     time_value: Option<&Value>,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3,15 +3,10 @@
 // Needed for AddOns, debug capabilities and custom primitives
 
 use crate::{
-    consts::{
-        is_blacklisted_setcode, is_sender_blacklisted, is_to_address_blacklisted, GnosisError,
-        DEFAULT_7702_PATCH_TIME, DEFAULT_EL_PATCH_TIME,
-    },
     payload::GnosisBuiltPayload,
     primitives::block::{GnosisBlock, IntoGnosisBlock, TransactionSigned},
-    spec::gnosis_spec::{GnosisChainSpec, GnosisHardForks},
+    spec::gnosis_spec::GnosisChainSpec,
 };
-use alloy_consensus::Transaction;
 use reth::rpc::types::engine::{ExecutionData, ExecutionPayload, ExecutionPayloadEnvelopeV5};
 use reth_ethereum_engine_primitives::{
     EthPayloadAttributes, ExecutionPayloadEnvelopeV2, ExecutionPayloadEnvelopeV3,
@@ -27,7 +22,7 @@ use reth_payload_builder::EthPayloadBuilderAttributes;
 use reth_primitives::{NodePrimitives, RecoveredBlock};
 use reth_primitives_traits::SealedBlock;
 use serde::{Deserialize, Serialize};
-use std::{env, sync::Arc};
+use std::sync::Arc;
 
 /// Custom engine types - uses a custom payload attributes RPC type, but uses the default
 /// payload builder attributes type.
@@ -95,37 +90,6 @@ impl PayloadValidator<GnosisEngineTypes> for GnosisEngineValidator {
         let block = sealed_block
             .try_recover()
             .map_err(|e| NewPayloadError::Other(e.into()))?;
-
-        if !self
-            .chain_spec()
-            .is_balancer_hardfork_active_at_timestamp(block.timestamp)
-            && block.timestamp
-                > env::var("GNOSIS_EL_PATCH_TIME")
-                    .unwrap_or(DEFAULT_EL_PATCH_TIME.to_string())
-                    .parse::<u64>()
-                    .unwrap_or_default()
-        {
-            let is_patch2_enabled: bool = block.timestamp
-                > env::var("GNOSIS_EL_7702_PATCH_TIME")
-                    .unwrap_or(DEFAULT_7702_PATCH_TIME.to_string())
-                    .parse::<u64>()
-                    .unwrap_or_default();
-
-            for (sender, tx) in block.transactions_with_sender() {
-                if is_sender_blacklisted(sender)
-                    || is_to_address_blacklisted(&tx.to().unwrap_or_default())
-                    || (is_patch2_enabled && is_blacklisted_setcode(tx))
-                {
-                    return Err(NewPayloadError::other(GnosisError::custom(format!(
-                            "Unable to proceed (ensure_well_formed_payload) - signer: {}, to: {:?}, block: {}, {}",
-                            &sender,
-                            &tx.to().unwrap_or_default(),
-                            &block.number,
-                            &block.hash()
-                        ))));
-                }
-            }
-        }
 
         Ok(block)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,6 @@
-use std::env;
-
 use clap::{Args, Parser};
 use reth_cli_commands::common::EnvironmentArgs;
 use reth_gnosis::cli::gnosis_cli::Commands;
-use reth_gnosis::consts::{DEFAULT_7702_PATCH_TIME, DEFAULT_EL_PATCH_TIME};
 use reth_gnosis::initialize::download_init_state::{CHIADO_DOWNLOAD_SPEC, GNOSIS_DOWNLOAD_SPEC};
 use reth_gnosis::initialize::import_and_ensure_state::download_and_import_init_state;
 use reth_gnosis::{
@@ -25,18 +22,6 @@ type CliGnosis = GnosisCli<GnosisChainSpecParser, NoArgs>;
 fn main() {
     let user_cli = CliGnosis::parse();
     let _guard = user_cli.init_tracing();
-
-    let timestamp = env::var("GNOSIS_EL_PATCH_TIME")
-        .unwrap_or(DEFAULT_EL_PATCH_TIME.to_string())
-        .parse::<u64>()
-        .unwrap_or_default();
-    println!("Gnosis EL Patch Time is set to: {timestamp}");
-
-    let is_patch2_enabled = env::var("GNOSIS_EL_7702_PATCH_TIME")
-        .unwrap_or(DEFAULT_7702_PATCH_TIME.to_string())
-        .parse::<u64>()
-        .unwrap_or_default();
-    println!("GNOSIS_EL_7702_PATCH_TIME Time is set to: {is_patch2_enabled}");
 
     // Fetch pre-merge state from a URL and load into the DB
     if let Commands::Node(ref node_cmd) = user_cli.command {

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,4 +1,4 @@
-use std::{env, sync::Arc};
+use std::sync::Arc;
 
 use alloy_consensus::Transaction;
 use alloy_eips::eip7685::Requests;
@@ -42,12 +42,8 @@ use revm_primitives::U256;
 use tracing::{debug, trace, warn};
 
 use crate::{
-    consts::{
-        is_blacklisted_setcode, is_sender_blacklisted, is_to_address_blacklisted, GnosisError,
-        DEFAULT_7702_PATCH_TIME, DEFAULT_EL_PATCH_TIME,
-    },
     primitives::{block::GnosisBlock, GnosisNodePrimitives},
-    spec::gnosis_spec::{GnosisChainSpec, GnosisHardForks},
+    spec::gnosis_spec::GnosisChainSpec,
 };
 
 type BestTransactionsIter<Pool> = Box<
@@ -226,37 +222,6 @@ where
     let is_osaka = chain_spec.is_osaka_active_at_timestamp(attributes.timestamp);
 
     while let Some(pool_tx) = best_txs.next() {
-        if !chain_spec.is_balancer_hardfork_active_at_timestamp(attributes.timestamp)
-            && attributes.timestamp
-                > env::var("GNOSIS_EL_PATCH_TIME")
-                    .unwrap_or(DEFAULT_EL_PATCH_TIME.to_string())
-                    .parse::<u64>()
-                    .unwrap_or_default()
-        {
-            let sender = pool_tx.sender();
-            let to = pool_tx.to().unwrap_or_default();
-
-            let is_patch2_enabled: bool = attributes.timestamp
-                > env::var("GNOSIS_EL_7702_PATCH_TIME")
-                    .unwrap_or(DEFAULT_7702_PATCH_TIME.to_string())
-                    .parse::<u64>()
-                    .unwrap_or_default();
-
-            if is_sender_blacklisted(&sender)
-                || is_to_address_blacklisted(&to)
-                || (is_patch2_enabled
-                    && is_blacklisted_setcode(&pool_tx.transaction.clone().into_consensus()))
-            {
-                best_txs.mark_invalid(
-                    &pool_tx,
-                    &InvalidPoolTransactionError::Other(Box::new(GnosisError::custom(
-                        "Cannot proceed with tx (payload building)",
-                    ))),
-                );
-                continue;
-            };
-        }
-
         // ensure we still have capacity for this transaction
         if cumulative_gas_used + pool_tx.gas_limit() > block_gas_limit {
             // we can't fit this transaction into the block, so we need to mark it as invalid


### PR DESCRIPTION
Removing all soft-fork related code. Essentially a revert of the softwork parts of https://github.com/gnosischain/reth_gnosis/pull/95, while keeping the hardfork codepaths.