### PR TITLE
fix: init-state now downloads to datadir

### DIFF
--- a/src/initialize/import_and_ensure_state.rs
+++ b/src/initialize/import_and_ensure_state.rs
@@ -124,7 +124,7 @@ pub fn download_and_import_init_state(
     let runtime = Runtime::new().expect("Unable to build runtime");
     let _guard = runtime.enter();
 
-    if let Err(e) = runtime.block_on(ensure_state(state_path, chain)) {
+    if let Err(e) = runtime.block_on(ensure_state(&state_path, chain)) {
         eprintln!("state setup failed: {e}");
         std::process::exit(1);
     }

--- a/src/initialize/import_and_ensure_state.rs
+++ b/src/initialize/import_and_ensure_state.rs
@@ -18,7 +18,7 @@ use reth_provider::{
 use revm_primitives::B256;
 use std::fs::File;
 use std::io::{BufReader, Read};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::str::FromStr;
 use tracing::info;
 
@@ -119,12 +119,11 @@ pub fn download_and_import_init_state(
         }
     }
 
-    let state_path_str = format!("./{chain}-state");
-    let state_path = Path::new(&state_path_str);
+    let state_path = datadir.join(format!("{chain}-state"));
 
     if let Err(e) = tokio_runtime()
         .expect("Unable to build runtime")
-        .block_on(ensure_state(state_path, chain))
+        .block_on(ensure_state(&state_path, chain))
     {
         eprintln!("state setup failed: {e}");
         std::process::exit(1);


### PR DESCRIPTION
Earlier the init state used to create a folder from the dir the node was started from. This creates issues for certain dockerized environments where r/w permissions are given only for the datadir. This PR now moves this download folder to inside the configure/default datadir.