### PR TITLE
rename gnosis primitives dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3633,7 +3633,7 @@ dependencies = [
 [[package]]
 name = "gnosis-primitives"
 version = "0.1.111"
-source = "git+https://github.com/gnosischain/gnosis-stuff.git?tag=v0.1.111#eba2de20b084291f9c0a53cc248b84c359574bc5"
+source = "git+https://github.com/gnosischain/gnosis-rust-primitives.git?tag=v0.1.111#eba2de20b084291f9c0a53cc248b84c359574bc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3633,7 +3633,7 @@ dependencies = [
 [[package]]
 name = "gnosis-primitives"
 version = "0.1.111"
-source = "git+https://github.com/gnosischain/gnosis-rust-primitives.git?tag=v0.1.111#eba2de20b084291f9c0a53cc248b84c359574bc5"
+source = "git+https://github.com/gnosischain/rust-primitives.git?tag=v0.1.111#eba2de20b084291f9c0a53cc248b84c359574bc5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "reth"
 path = "src/main.rs"
 
 [dependencies]
-gnosis-primitives = { git = "https://github.com/gnosischain/gnosis-rust-primitives.git", tag = "v0.1.111" }
+gnosis-primitives = { git = "https://github.com/gnosischain/rust-primitives.git", tag = "v0.1.111" }
 
 reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
 reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "reth"
 path = "src/main.rs"
 
 [dependencies]
-gnosis-primitives = { git = "https://github.com/gnosischain/gnosis-stuff.git", tag = "v0.1.111" }
+gnosis-primitives = { git = "https://github.com/gnosischain/gnosis-rust-primitives.git", tag = "v0.1.111" }
 
 reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
 reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }


### PR DESCRIPTION
Updates the dependency name to use https://github.com/gnosischain/gnosis-rust-primitives