### PR TITLE
feat: add snapshot API URL support for Gnosis Chain and Chiado

### DIFF
--- a/src/cli/gnosis_cli.rs
+++ b/src/cli/gnosis_cli.rs
@@ -12,7 +12,9 @@ use reth::{
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::{
     common::CliComponentsBuilder,
-    config_cmd, db, download, dump_genesis, export_era, import, init_cmd, init_state,
+    config_cmd, db,
+    download::{self, manifest_cmd},
+    dump_genesis, export_era, import, init_cmd, init_state,
     launcher::FnLauncher,
     node::{self, NoArgs},
     p2p, prune, re_execute, stage,
@@ -203,6 +205,7 @@ where
             Commands::Download(command) => {
                 runner.run_blocking_until_ctrl_c(command.execute::<GnosisNode>())
             }
+            Commands::SnapshotManifest(command) => command.execute(),
             Commands::ExportEra(command) => {
                 runner.run_blocking_until_ctrl_c(command.execute::<GnosisNode>(rt))
             }
@@ -258,6 +261,9 @@ pub enum Commands<C: ChainSpecParser, Ext: clap::Args + fmt::Debug> {
     /// Download public node snapshots
     #[command(name = "download")]
     Download(download::DownloadCommand<C>),
+    /// Generate a snapshot manifest from local archive files.
+    #[command(name = "snapshot-manifest")]
+    SnapshotManifest(manifest_cmd::SnapshotManifestCommand),
     /// Manipulate individual stages.
     #[command(name = "stage")]
     Stage(stage::Command<C>),
@@ -288,6 +294,7 @@ impl<C: ChainSpecParser, Ext: clap::Args + fmt::Debug> Commands<C, Ext> {
             Self::DumpGenesis(cmd) => cmd.chain_spec(),
             Self::Db(cmd) => cmd.chain_spec(),
             Self::Download(cmd) => cmd.chain_spec(),
+            Self::SnapshotManifest(_) => None,
             Self::Stage(cmd) => cmd.chain_spec(),
             Self::P2P(cmd) => cmd.chain_spec(),
             Self::Config(_) => None,

--- a/src/initialize/mod.rs
+++ b/src/initialize/mod.rs
@@ -9,3 +9,5 @@ pub const MAINNET_ERA_IMPORT_HEIGHT: u64 = 25_349_537; // Gnosis Chain
 // REFERENCE MERGE BLOCKS:
 // - Gnosis mainnet: block 25,349,537
 // - Chiado testnet: block 680,930
+
+pub const SNAPSHOT_API_URL: &str = "https://reth-snapshots.gnosischain.com/api/snapshots";

--- a/src/initialize/mod.rs
+++ b/src/initialize/mod.rs
@@ -10,4 +10,4 @@ pub const MAINNET_ERA_IMPORT_HEIGHT: u64 = 25_349_537; // Gnosis Chain
 // - Gnosis mainnet: block 25,349,537
 // - Chiado testnet: block 680,930
 
-pub const SNAPSHOT_API_URL: &str = "https://reth-snapshots.gnosischain.com/api/snapshots";
+pub const SNAPSHOT_API_URL: &str = "https://reth-snapshots.gnosischain.com";

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,12 @@ use clap::{Args, Parser};
 use reth::api::FullNodeComponents;
 use reth::args::DefaultStorageValues;
 use reth_cli_commands::common::EnvironmentArgs;
+use reth_cli_commands::download::DownloadDefaults;
 use reth_gnosis::cli::gnosis_cli::Commands;
 use reth_gnosis::engine::GnosisEngineValidator;
 use reth_gnosis::initialize::download_init_state::{CHIADO_DOWNLOAD_SPEC, GNOSIS_DOWNLOAD_SPEC};
 use reth_gnosis::initialize::import_and_ensure_state::download_and_import_init_state;
+use reth_gnosis::initialize::SNAPSHOT_API_URL;
 use reth_gnosis::{
     cli::gnosis_cli::GnosisCli, spec::gnosis_spec::GnosisChainSpecParser, GnosisNode,
 };
@@ -43,6 +45,18 @@ pub struct GnosisExt {
 type CliGnosis = GnosisCli<GnosisChainSpecParser, GnosisExt>;
 
 fn main() {
+    let _ = DownloadDefaults::default()
+        .with_snapshot_api_url(SNAPSHOT_API_URL)
+        .with_long_help(format!(
+            "Snapshots for Gnosis Chain and Chiado.\n\n\
+            Auto-discovery: `reth download --chain chiado` (or `--chain gnosis`) picks \
+            the latest snapshot from {SNAPSHOT_API_URL}.\n\n\
+            Manual: pass --manifest-url with one of:\n    \
+                {SNAPSHOT_API_URL}/latest/chiado/manifest.json\n    \
+                {SNAPSHOT_API_URL}/latest/gnosis/manifest.json",
+        ))
+        .try_init();
+
     let user_cli = CliGnosis::parse();
     let _guard = user_cli.init_tracing();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ type CliGnosis = GnosisCli<GnosisChainSpecParser, GnosisExt>;
 
 fn main() {
     let _ = DownloadDefaults::default()
-        .with_snapshot_api_url(SNAPSHOT_API_URL)
+        .with_snapshot_api_url(format!("{}/api/snapshots", SNAPSHOT_API_URL))
         .with_long_help(format!(
             "Snapshots for Gnosis Chain and Chiado.\n\n\
             Auto-discovery: `reth download --chain chiado` (or `--chain gnosis`) picks \


### PR DESCRIPTION
this enables snapshot downloads for reth_gnosis. snapshots are hosted at https://reth-snapshots.gnosischain.com/api/snapshots with only one chiado snapshot hosted currently (will edit as more get out).

try it out with:

```sh
./target/release/reth download --chain chiado --datadir snapshot-test-dir
```

you will be greeted with this TUI:

```txt
┌reth download────────────────────────────────────────────────────────────────────┐
│ Select snapshot components to download (block 21351053)                         │
└─────────────────────────────────────────────────────────────────────────────────┘
┌Components — Total: 8.02 GB──────────────────────────────────────────────────────┐
│▸  State (mdbx)              All            4.18 GB (required)                   │
│   Headers                   All            3.72 GB (required)                   │
│   Transactions            ▸ Last 10064 blocks  60.17 MB                         │
│   Receipts                ▸ Last 64 blocks  11.39 MB                            │
│   State History           ▸ Last 10064 blocks  49.63 MB                         │
└─────────────────────────────────────────────────────────────────────────────────┘
┌─────────────────────────────────────────────────────────────────────────────────┐
│ [←/→] adjust  [m] minimal  [f] full  [a] archive  [Enter] confirm  [Esc] cancel │
└─────────────────────────────────────────────────────────────────────────────────┘
```